### PR TITLE
Allow plugin to be loaded as a regular WP Plugin as well.

### DIFF
--- a/rbm-field-helpers.php
+++ b/rbm-field-helpers.php
@@ -1,5 +1,13 @@
 <?php
 /**
+ * Plugin Name: RBM Field Helpers
+ * Description: Provides helper functions shared among all RBM plugins.
+ * Version: 1.2.0
+ * Author: Real Big Marketing
+ * Author URI: http://realbigmarketing.com
+ */
+
+/**
  * Provides helper functions shared among all RBM plugins.
  *
  * @version 1.2.0


### PR DESCRIPTION
Works better in Multisite environments were HTACCESS Rules can break this by blocking resources from being loaded (CORS).