### PR TITLE
Issue/40/template override

### DIFF
--- a/core/class-rbm-fh-field-templates.php
+++ b/core/class-rbm-fh-field-templates.php
@@ -65,13 +65,7 @@ class RBM_FH_FieldTemplates {
 	 */
 	function do_field( $type, $args, $name, $value ) {
 		
-		if ( isset( $this->instance['file'] ) && 
-			is_file( dirname( $this->instance['file'] ) . '/rbm-field-helpers/field.php' ) ) {
-			include dirname( $this->instance['file'] ) . '/rbm-field-helpers/field.php';
-		}
-		else {
-			include __DIR__ . '/fields/views/field.php';
-		}
+		include $this->maybe_override_template( '/fields/views/field.php' );
 		
 	}
 
@@ -88,13 +82,7 @@ class RBM_FH_FieldTemplates {
 	 */
 	function template_field( $type, $args, $name, $value ) {
 		
-		if ( isset( $this->instance['file'] ) && 
-			is_file( dirname( $this->instance['file'] ) . "/rbm-field-helpers/field-{$type}.php" ) ) {
-			include dirname( $this->instance['file'] ) . "/rbm-field-helpers/field-{$type}.php";
-		}
-		else {
-			include __DIR__ . "/fields/views/fields/field-{$type}.php";
-		}
+		include $this->maybe_override_template( "/fields/views/fields/field-{$type}.php" );
 		
 	}
 
@@ -111,13 +99,7 @@ class RBM_FH_FieldTemplates {
 	 */
 	function template_label( $type, $args, $name, $value ) {
 		
-		if ( isset( $this->instance['file'] ) && 
-			is_file( dirname( $this->instance['file'] ) . '/rbm-field-helpers/field-label.php' ) ) {
-			include dirname( $this->instance['file'] ) . '/rbm-field-helpers/field-label.php';
-		}
-		else {
-			include __DIR__ . '/fields/views/field-label.php';
-		}
+		include $this->maybe_override_template( '/fields/views/field-label.php' );
 		
 	}
 
@@ -174,24 +156,44 @@ class RBM_FH_FieldTemplates {
 
 		if ( $args['description_tip'] === true ) {
 			
-			if ( isset( $this->instance['file'] ) && 
-				is_file( dirname( $this->instance['file'] ) . '/rbm-field-helpers/field-description-tip.php' ) ) {
-				include dirname( $this->instance['file'] ) . '/rbm-field-helpers/field-description-tip.php';
-			}
-			else {
-				include __DIR__ . '/fields/views/field-description-tip.php';
-			}
+			include $this->maybe_override_template( '/fields/views/field-description-tip.php' );
 
 		} else {
 			
-			if ( isset( $this->instance['file'] ) && 
-				is_file( dirname( $this->instance['file'] ) . '/rbm-field-helpers/field-description.php' ) ) {
-				include dirname( $this->instance['file'] ) . '/rbm-field-helpers/field-description.php';
-			}
-			else {
-				include __DIR__ . '/fields/views/field-description.php';
-			}
+			include $this->maybe_override_template( '/fields/views/field-description.php' );
 			
 		}
 	}
+	
+	/**
+	 * Load an alternate Field Template if one exists in your Theme/Plugin
+	 * 
+	 * @since {{VERSION}}
+	 * @access private
+	 * 
+	 * @param  string $template_file Relative File Path to the Template File
+	 * @return string Absolute File Path to the Template File
+	 */
+	function maybe_override_template( $template_file ) {
+		
+		$prefix = $this->instance['ID'];
+		
+		/**
+		 * Allows changing the Directory that Field Template Overrides in your Theme/Plugin should be loaded from
+		 * 
+		 * @param string Relative Directory Path to the inclusion of your 
+		 * @since {{VERSION}}
+		 */
+		$override_directory = trailingslashit( apply_filters( "{$prefix}_fieldhelpers_field_template_override_directory", '/rbm-field-helpers' ) );
+		
+		if ( isset( $this->instance['file'] ) && 
+			is_file( dirname( $this->instance['file'] ) . $override_directory . $template_file ) ) {
+			return dirname( $this->instance['file'] ) . $override_directory . $template_file;
+		}
+		else {
+			return __DIR__ . $template_file;
+		}
+		
+	}
+	
 }

--- a/core/class-rbm-fh-field-templates.php
+++ b/core/class-rbm-fh-field-templates.php
@@ -64,8 +64,15 @@ class RBM_FH_FieldTemplates {
 	 * @param mixed $value Field value.
 	 */
 	function do_field( $type, $args, $name, $value ) {
-
-		include __DIR__ . '/fields/views/field.php';
+		
+		if ( isset( $this->instance['file'] ) && 
+			is_file( dirname( $this->instance['file'] ) . '/rbm-field-helpers/field.php' ) ) {
+			include dirname( $this->instance['file'] ) . '/rbm-field-helpers/field.php';
+		}
+		else {
+			include __DIR__ . '/fields/views/field.php';
+		}
+		
 	}
 
 	/**
@@ -80,8 +87,15 @@ class RBM_FH_FieldTemplates {
 	 * @param mixed $value Field value.
 	 */
 	function template_field( $type, $args, $name, $value ) {
-
-		include __DIR__ . "/fields/views/fields/field-{$type}.php";
+		
+		if ( isset( $this->instance['file'] ) && 
+			is_file( dirname( $this->instance['file'] ) . "/rbm-field-helpers/field-{$type}.php" ) ) {
+			include dirname( $this->instance['file'] ) . "/rbm-field-helpers/field-{$type}.php";
+		}
+		else {
+			include __DIR__ . "/fields/views/fields/field-{$type}.php";
+		}
+		
 	}
 
 	/**
@@ -96,8 +110,15 @@ class RBM_FH_FieldTemplates {
 	 * @param mixed $value Field value.
 	 */
 	function template_label( $type, $args, $name, $value ) {
-
-		include __DIR__ . '/fields/views/field-label.php';
+		
+		if ( isset( $this->instance['file'] ) && 
+			is_file( dirname( $this->instance['file'] ) . '/rbm-field-helpers/field-label.php' ) ) {
+			include dirname( $this->instance['file'] ) . '/rbm-field-helpers/field-label.php';
+		}
+		else {
+			include __DIR__ . '/fields/views/field-label.php';
+		}
+		
 	}
 
 	/**
@@ -152,12 +173,25 @@ class RBM_FH_FieldTemplates {
 	function template_description( $type, $args, $name, $value ) {
 
 		if ( $args['description_tip'] === true ) {
-
-			include __DIR__ . '/fields/views/field-description-tip.php';
+			
+			if ( isset( $this->instance['file'] ) && 
+				is_file( dirname( $this->instance['file'] ) . '/rbm-field-helpers/field-description-tip.php' ) ) {
+				include dirname( $this->instance['file'] ) . '/rbm-field-helpers/field-description-tip.php';
+			}
+			else {
+				include __DIR__ . '/fields/views/field-description-tip.php';
+			}
 
 		} else {
-
-			include __DIR__ . '/fields/views/field-description.php';
+			
+			if ( isset( $this->instance['file'] ) && 
+				is_file( dirname( $this->instance['file'] ) . '/rbm-field-helpers/field-description.php' ) ) {
+				include dirname( $this->instance['file'] ) . '/rbm-field-helpers/field-description.php';
+			}
+			else {
+				include __DIR__ . '/fields/views/field-description.php';
+			}
+			
 		}
 	}
 }

--- a/core/class-rbm-fh-field-templates.php
+++ b/core/class-rbm-fh-field-templates.php
@@ -172,27 +172,51 @@ class RBM_FH_FieldTemplates {
 	 * @access private
 	 * 
 	 * @param  string $template_file Relative File Path to the Template File
+	 * @param string $type Field type.
+	 * @param array $args Field arguments.
+	 * @param string $name Field name.
+	 * @param mixed $value Field value.
 	 * @return string Absolute File Path to the Template File
 	 */
-	function maybe_override_template( $template_file ) {
+	function maybe_override_template( $template_file, $type, $args, $name, $value ) {
 		
 		$prefix = $this->instance['ID'];
 		
 		/**
 		 * Allows changing the Directory that Field Template Overrides in your Theme/Plugin should be loaded from
 		 * 
-		 * @param string Relative Directory Path to the inclusion of your 
+		 * @param string Relative Directory Path to the inclusion of your Field Template Overrides
+		 * @param string Relative File Path to the Template File
+		 * @param string Field type.
+	 	 * @param array Field arguments.
+	 	 * @param string Field name.
+	 	 * @param mixed Field value.
 		 * @since {{VERSION}}
 		 */
-		$override_directory = trailingslashit( apply_filters( "{$prefix}_fieldhelpers_field_template_override_directory", '/rbm-field-helpers' ) );
+		$override_directory = trailingslashit( apply_filters( "{$prefix}_fieldhelpers_field_template_override_directory", '/rbm-field-helpers', $template_file, $type, $args, $name, $value ) );
+		
+		$result = '';
 		
 		if ( isset( $this->instance['file'] ) && 
 			is_file( dirname( $this->instance['file'] ) . $override_directory . $template_file ) ) {
-			return dirname( $this->instance['file'] ) . $override_directory . $template_file;
+			$result = dirname( $this->instance['file'] ) . $override_directory . $template_file;
 		}
 		else {
-			return __DIR__ . $template_file;
+			$result = __DIR__ . $template_file;
 		}
+		
+		/**
+		 * Allows changing the loaded Template File per-Field. This occurs after the override has been applied.
+		 * 
+		 * @param string Relative Directory Path to the inclusion of your Field Template Overrides
+		 * @param string Relative File Path to the Template File
+		 * @param string Field type.
+	 	 * @param array Field arguments.
+	 	 * @param string Field name.
+	 	 * @param mixed Field value.
+	 	 * @since {{VERSION}}
+		 */
+		return apply_filters( "{$prefix}_fieldhelpers_after_override_field_template_path", $result, $template_file, $type, $args, $name, $value );
 		
 	}
 	


### PR DESCRIPTION
Referencing #40

This is something that I initially thought of when I saw that the Fields were getting loaded from template files. This adds another bit to the `instance` called `file` which is just `__FILE__` from where the Constructor is called for the main RBM FH Object.

I'm a little worried that `file` is ambiguous, so any alternate naming for it is welcome :+1: