### PR TITLE
Support being loaded by a Theme

### DIFF
--- a/rbm-field-helpers.php
+++ b/rbm-field-helpers.php
@@ -10,8 +10,26 @@ defined( 'ABSPATH' ) || die();
 if ( ! class_exists( 'RBM_FieldHelpers' ) ) {
 
 	define( 'RBM_FIELD_HELPERS_VER', '1.4.2' );
-	define( 'RBM_FIELD_HELPERS_URI', plugins_url( '', __FILE__ ) );
-	define( 'RBM_FIELD_HELPERS_DIR', plugin_dir_path( __FILE__ ) );
+	
+	if ( strpos( __FILE__, WP_PLUGIN_DIR ) !== false ) {
+	
+		define( 'RBM_FIELD_HELPERS_URI', plugins_url( '', __FILE__ ) );
+		define( 'RBM_FIELD_HELPERS_DIR', plugin_dir_path( __FILE__ ) );
+		
+	}
+	else {
+		
+		$theme_dir = get_stylesheet_directory();
+		
+		// Relative path from the Theme Directory to the directory holding RBM FH
+		$relative_from_theme_dir = dirname( str_replace( $theme_dir, '', __FILE__ ) );
+		
+		// Build out our Constants for DIR and URI
+		// DIR could have been made using just dirname( __FILE__ ), but we needed the difference to create the URI anyway
+		define( 'RBM_FIELD_HELPERS_URI', get_stylesheet_directory_uri() . $relative_from_theme_dir );
+		define( 'RBM_FIELD_HELPERS_DIR', $theme_dir . $relative_from_theme_dir );
+		
+	}
 
 	final class RBM_FieldHelpers {
 


### PR DESCRIPTION
Generally stuff like this would be kept out of the display logic, but occasionally it makes sense to keep fields as part of the Theme. Like for a specific Page Template that is specific to that Theme.

When defining the DIR and URI Constants it just checks if `__FILE__` contains `WP_PLUGIN_DIR`. If it doesn't, it builds it out using the active Theme's DIR and URI.