### PR TITLE
Fixes l10n for Repeaters and Media Field Types

### DIFF
--- a/core/class-rbm-fh-fields.php
+++ b/core/class-rbm-fh-fields.php
@@ -436,7 +436,7 @@ class RBM_FH_Fields {
 			'type'        => $field->args['type'],
 			'previewSize' => $field->args['preview_size'],
 			'l10n'        => array(
-				'window_title' => $field->args['window_title'],
+				'window_title' => $field->args['l10n']['window_title'],
 			),
 		) );
 	}
@@ -591,10 +591,10 @@ class RBM_FH_Fields {
 			'sortable'               => $field->args['sortable'],
 			'isFirstItemUndeletable' => $field->args['first_item_undeletable'],
 			'l10n'                   => array(
-				'collapsable_title'   => $field->args['collapsable_title'],
-				'confirm_delete_text' => $field->args['confirm_delete_text'],
-				'delete_item_text'    => $field->args['delete_item_text'],
-				'add_item_text'       => $field->args['add_item_text'],
+				'collapsable_title'   => $field->args['l10n']['collapsable_title'],
+				'confirm_delete_text' => $field->args['l10n']['confirm_delete'],
+				'delete_item_text'    => $field->args['l10n']['delete_item'],
+				'add_item_text'       => $field->args['l10n']['add_item'],
 			),
 		) );
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "RBMFieldHelpers",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -100,9 +100,18 @@
       "dev": true
     },
     "ansi-colors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.0.1.tgz",
-      "integrity": "sha512-yopkAU0ZD/WQ56Tms3xLn6jRuX3SyUMAVi0FdmDIbmmnHW3jHiI1sQFdUl3gfVddjnrsP3Y6ywFKvCRopvoVIA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
+      "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
+      "dev": true,
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
+    },
+    "ansi-gray": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
+      "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
       "dev": true,
       "requires": {
         "ansi-wrap": "0.1.0"
@@ -251,43 +260,37 @@
       "dev": true
     },
     "array-initial": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/array-initial/-/array-initial-1.0.1.tgz",
-      "integrity": "sha1-hhIiIqKcHtQjR/YzQRGvpA+LIOw=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/array-initial/-/array-initial-1.1.0.tgz",
+      "integrity": "sha1-L6dLJnOTccOUe9enrcc74zSz15U=",
       "dev": true,
       "requires": {
         "array-slice": "1.0.0",
-        "is-number": "3.0.0"
+        "is-number": "4.0.0"
       },
       "dependencies": {
         "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          }
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "dev": true
         }
       }
     },
     "array-last": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/array-last/-/array-last-1.2.0.tgz",
-      "integrity": "sha1-CISmfsKsKggTP8APZnec/tsBCYY=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/array-last/-/array-last-1.3.0.tgz",
+      "integrity": "sha512-eOCut5rXlI6aCOS7Z7kCplKRKyiFQ6dHFBem4PwlwKeNFk2/XxTrhRh5T9PyaEWGy/NHTZWbY+nsZlNFJu9rYg==",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0"
+        "is-number": "4.0.0"
       },
       "dependencies": {
         "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          }
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "dev": true
         }
       }
     },
@@ -382,9 +385,9 @@
       "dev": true
     },
     "async-done": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/async-done/-/async-done-1.2.3.tgz",
-      "integrity": "sha1-bHq8fWHKJ/5vHyujIG6prmCkOYM=",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/async-done/-/async-done-1.2.4.tgz",
+      "integrity": "sha512-mxc+yISkb0vjsuvG3dJCIZXzRWjKndQ9Zo9zNDJ1K2wh9eP0E0oGmOWm+4cFOvW4dA0tGFImTW5tQJHCtn1kIQ==",
       "dev": true,
       "requires": {
         "end-of-stream": "1.4.0",
@@ -423,7 +426,7 @@
       "integrity": "sha1-HQqRS7Aldb7IqPOnTlCA9yssDGs=",
       "dev": true,
       "requires": {
-        "async-done": "1.2.3"
+        "async-done": "1.2.4"
       }
     },
     "asynckit": {
@@ -1017,9 +1020,9 @@
         "arr-flatten": "1.1.0",
         "arr-map": "2.0.2",
         "array-each": "1.0.1",
-        "array-initial": "1.0.1",
-        "array-last": "1.2.0",
-        "async-done": "1.2.3",
+        "array-initial": "1.1.0",
+        "array-last": "1.3.0",
+        "async-done": "1.2.4",
         "async-settle": "1.0.0",
         "now-and-later": "2.0.0"
       }
@@ -1047,15 +1050,18 @@
         "component-emitter": "1.2.1",
         "define-property": "1.0.0",
         "isobject": "3.0.1",
-        "mixin-deep": "1.3.0",
+        "mixin-deep": "1.3.1",
         "pascalcase": "0.1.1"
       },
       "dependencies": {
-        "component-emitter": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-          "dev": true
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "1.0.2"
+          }
         },
         "isobject": {
           "version": "3.0.1",
@@ -1736,12 +1742,6 @@
         "unset-value": "1.0.0"
       },
       "dependencies": {
-        "component-emitter": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-          "dev": true
-        },
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
@@ -2126,6 +2126,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
       "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E=",
+      "dev": true
+    },
+    "component-emitter": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
       "dev": true
     },
     "component-inherit": {
@@ -2759,12 +2765,21 @@
       }
     },
     "define-property": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-      "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "dev": true,
       "requires": {
-        "is-descriptor": "1.0.2"
+        "is-descriptor": "1.0.2",
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
       }
     },
     "delayed-stream": {
@@ -4754,6 +4769,18 @@
         }
       }
     },
+    "glob-watcher": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-4.0.0.tgz",
+      "integrity": "sha1-nmOo/25h6TLebMLK7OUHGm1zcyk=",
+      "dev": true,
+      "requires": {
+        "async-done": "1.2.4",
+        "chokidar": "1.7.0",
+        "just-debounce": "1.0.0",
+        "object.defaults": "1.1.0"
+      }
+    },
     "global-modules": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
@@ -4904,9 +4931,9 @@
       "dev": true,
       "requires": {
         "glob-watcher": "4.0.0",
-        "gulp-cli": "2.0.0",
+        "gulp-cli": "2.0.1",
         "undertaker": "1.2.0",
-        "vinyl-fs": "3.0.1"
+        "vinyl-fs": "3.0.2"
       },
       "dependencies": {
         "arr-diff": {
@@ -4922,9 +4949,9 @@
           "dev": true
         },
         "braces": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.0.tgz",
-          "integrity": "sha512-P4O8UQRdGiMLWSizsApmXVQDBS6KCt7dSexgLKBmH5Hr1CZq7vsnscFh8oR1sP1ab1Zj0uCHCEzZeV6SfUf3rA==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.1.tgz",
+          "integrity": "sha512-SO5lYHA3vO6gz66erVvedSCkp7AKWdv6VcQ2N4ysXfPxdAlxAMMAdwegGGcv1Bqwm7naF1hNdk5d6AAIEHV2nQ==",
           "dev": true,
           "requires": {
             "arr-flatten": "1.1.0",
@@ -4933,11 +4960,32 @@
             "extend-shallow": "2.0.1",
             "fill-range": "4.0.0",
             "isobject": "3.0.1",
+            "kind-of": "6.0.2",
             "repeat-element": "1.1.2",
             "snapdragon": "0.8.1",
             "snapdragon-node": "2.1.1",
             "split-string": "3.1.0",
             "to-regex": "3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "1.0.2"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            }
           }
         },
         "camelcase": {
@@ -4984,7 +5032,7 @@
             "define-property": "0.2.5",
             "extend-shallow": "2.0.1",
             "posix-character-classes": "0.1.1",
-            "regex-not": "1.0.0",
+            "regex-not": "1.0.2",
             "snapdragon": "0.8.1",
             "to-regex": "3.0.1"
           },
@@ -4997,6 +5045,32 @@
               "requires": {
                 "is-descriptor": "0.1.6"
               }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
+              }
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "dev": true
             }
           }
         },
@@ -5007,6 +5081,27 @@
           "dev": true,
           "requires": {
             "homedir-polyfill": "1.0.1"
+          }
+        },
+        "extend-shallow": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+          "dev": true,
+          "requires": {
+            "assign-symbols": "1.0.0",
+            "is-extendable": "1.0.1"
+          },
+          "dependencies": {
+            "is-extendable": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+              "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+              "dev": true,
+              "requires": {
+                "is-plain-object": "2.0.4"
+              }
+            }
           }
         },
         "extglob": {
@@ -5020,9 +5115,40 @@
             "expand-brackets": "2.1.4",
             "extend-shallow": "2.0.1",
             "fragment-cache": "0.2.1",
-            "regex-not": "1.0.0",
+            "regex-not": "1.0.2",
             "snapdragon": "0.8.1",
             "to-regex": "3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "1.0.2"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            }
+          }
+        },
+        "fancy-log": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
+          "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
+          "dev": true,
+          "requires": {
+            "ansi-gray": "0.1.1",
+            "color-support": "1.1.3",
+            "time-stamp": "1.1.0"
           }
         },
         "fill-range": {
@@ -5035,6 +5161,17 @@
             "is-number": "3.0.0",
             "repeat-string": "1.6.1",
             "to-regex-range": "2.1.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            }
           }
         },
         "findup-sync": {
@@ -5045,9 +5182,15 @@
           "requires": {
             "detect-file": "1.0.0",
             "is-glob": "3.1.0",
-            "micromatch": "3.1.5",
+            "micromatch": "3.1.8",
             "resolve-dir": "1.0.1"
           }
+        },
+        "flagged-respawn": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.0.tgz",
+          "integrity": "sha1-Tnmumy6zi/hrO7Vr8+ClaqX8q9c=",
+          "dev": true
         },
         "glob": {
           "version": "7.1.2",
@@ -5091,18 +5234,6 @@
             "unique-stream": "2.2.1"
           }
         },
-        "glob-watcher": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-4.0.0.tgz",
-          "integrity": "sha1-nmOo/25h6TLebMLK7OUHGm1zcyk=",
-          "dev": true,
-          "requires": {
-            "async-done": "1.2.3",
-            "chokidar": "1.7.0",
-            "just-debounce": "1.0.0",
-            "object.defaults": "1.1.0"
-          }
-        },
         "global-modules": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
@@ -5110,7 +5241,7 @@
           "dev": true,
           "requires": {
             "global-prefix": "1.0.2",
-            "is-windows": "1.0.1",
+            "is-windows": "1.0.2",
             "resolve-dir": "1.0.1"
           }
         },
@@ -5123,27 +5254,27 @@
             "expand-tilde": "2.0.2",
             "homedir-polyfill": "1.0.1",
             "ini": "1.3.4",
-            "is-windows": "1.0.1",
+            "is-windows": "1.0.2",
             "which": "1.3.0"
           }
         },
         "gulp-cli": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.0.0.tgz",
-          "integrity": "sha1-fwSa0pjtOIzam9gTtdcGJAfWLK0=",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.0.1.tgz",
+          "integrity": "sha512-RxujJJdN8/O6IW2nPugl7YazhmrIEjmiVfPKrWt68r71UCaLKS71Hp0gpKT+F6qOUFtr7KqtifDKaAJPRVvMYQ==",
           "dev": true,
           "requires": {
-            "ansi-colors": "1.0.1",
+            "ansi-colors": "1.1.0",
             "archy": "1.0.0",
             "array-sort": "1.0.0",
             "color-support": "1.1.3",
             "concat-stream": "1.6.0",
             "copy-props": "2.0.1",
-            "fancy-log": "1.3.0",
+            "fancy-log": "1.3.2",
             "gulplog": "1.0.0",
-            "interpret": "1.0.4",
+            "interpret": "1.1.0",
             "isobject": "3.0.1",
-            "liftoff": "2.3.0",
+            "liftoff": "2.5.0",
             "matchdep": "2.0.0",
             "mute-stdout": "1.0.0",
             "pretty-hrtime": "1.0.3",
@@ -5153,6 +5284,12 @@
             "yargs": "7.1.0"
           }
         },
+        "interpret": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+          "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
+          "dev": true
+        },
         "is-absolute": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
@@ -5160,7 +5297,7 @@
           "dev": true,
           "requires": {
             "is-relative": "1.0.0",
-            "is-windows": "1.0.1"
+            "is-windows": "1.0.2"
           }
         },
         "is-accessor-descriptor": {
@@ -5200,25 +5337,6 @@
               "requires": {
                 "is-buffer": "1.1.6"
               }
-            }
-          }
-        },
-        "is-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-              "dev": true
             }
           }
         },
@@ -5282,9 +5400,9 @@
           "dev": true
         },
         "is-windows": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.1.tgz",
-          "integrity": "sha1-MQ23D3QtJZoWo2kgK1GvhCMzENk=",
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+          "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
           "dev": true
         },
         "isobject": {
@@ -5299,6 +5417,22 @@
           "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         },
+        "liftoff": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.5.0.tgz",
+          "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
+          "dev": true,
+          "requires": {
+            "extend": "3.0.1",
+            "findup-sync": "2.0.0",
+            "fined": "1.1.0",
+            "flagged-respawn": "1.0.0",
+            "is-plain-object": "2.0.4",
+            "object.map": "1.0.1",
+            "rechoir": "0.6.2",
+            "resolve": "1.5.0"
+          }
+        },
         "matchdep": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/matchdep/-/matchdep-2.0.0.tgz",
@@ -5306,28 +5440,28 @@
           "dev": true,
           "requires": {
             "findup-sync": "2.0.0",
-            "micromatch": "3.1.5",
+            "micromatch": "3.1.8",
             "resolve": "1.5.0",
             "stack-trace": "0.0.10"
           }
         },
         "micromatch": {
-          "version": "3.1.5",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.5.tgz",
-          "integrity": "sha512-ykttrLPQrz1PUJcXjwsTUjGoPJ64StIGNE2lGVD1c9CuguJ+L7/navsE8IcDNndOoCMvYV0qc/exfVbMHkUhvA==",
+          "version": "3.1.8",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.8.tgz",
+          "integrity": "sha512-/XeuOQqYg+B5kwjDWekXseSwGS7CzE0w9Gjo4Cjkf/uFitNh47NrZHAY2vp/oS2YQVfebPIdbEIvgdy+kIcAog==",
           "dev": true,
           "requires": {
             "arr-diff": "4.0.0",
             "array-unique": "0.3.2",
-            "braces": "2.3.0",
-            "define-property": "1.0.0",
-            "extend-shallow": "2.0.1",
+            "braces": "2.3.1",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
             "extglob": "2.0.4",
             "fragment-cache": "0.2.1",
             "kind-of": "6.0.2",
-            "nanomatch": "1.2.7",
+            "nanomatch": "1.2.9",
             "object.pick": "1.3.0",
-            "regex-not": "1.0.0",
+            "regex-not": "1.0.2",
             "snapdragon": "0.8.1",
             "to-regex": "3.0.1"
           }
@@ -5397,12 +5531,11 @@
           }
         },
         "vinyl-fs": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-3.0.1.tgz",
-          "integrity": "sha1-dK9faDahz0FNNe6zwQ8uZfwqLBA=",
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-3.0.2.tgz",
+          "integrity": "sha512-AUSFda1OukBwuLPBTbyuO4IRWgfXmqC4UTW0f8xrCa8Hkv9oyIU+NSqBlgfOLZRoUt7cHdo75hKQghCywpIyIw==",
           "dev": true,
           "requires": {
-            "flush-write-stream": "1.0.2",
             "fs-mkdirp-stream": "1.0.0",
             "glob-stream": "6.1.0",
             "graceful-fs": "4.1.11",
@@ -5411,6 +5544,7 @@
             "lead": "1.0.0",
             "object.assign": "4.1.0",
             "pumpify": "1.4.0",
+            "readable-stream": "2.3.3",
             "remove-bom-buffer": "3.0.0",
             "remove-bom-stream": "1.2.0",
             "resolve-options": "1.1.0",
@@ -6537,22 +6671,19 @@
       "dev": true
     },
     "is-odd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-1.0.0.tgz",
-      "integrity": "sha1-O4qTLrAos3dcObsJ6RdnrM22kIg=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
+      "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0"
+        "is-number": "4.0.0"
       },
       "dependencies": {
         "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          }
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "dev": true
         }
       }
     },
@@ -7356,9 +7487,9 @@
       }
     },
     "marked": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
-      "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc=",
+      "version": "0.3.16",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.16.tgz",
+      "integrity": "sha512-diLiAxHidES67uJ1P5unXBUB4CyOFwodKrctuK0U4Ogw865N9Aw4dLmY0BK0tGKOy3xvkdMGgUXPD6W9z1Ne0Q==",
       "dev": true
     },
     "matchdep": {
@@ -7562,9 +7693,9 @@
       "dev": true
     },
     "mixin-deep": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.0.tgz",
-      "integrity": "sha512-dgaCvoh6i1nosAUBKb0l0pfJ78K8+S9fluyIR2YvAeUD/QuMahnFnF3xYty5eYXMjhGSsB0DsW6A0uAZyetoAg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
       "dev": true,
       "requires": {
         "for-in": "1.0.2",
@@ -7624,20 +7755,21 @@
       "dev": true
     },
     "nanomatch": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.7.tgz",
-      "integrity": "sha512-/5ldsnyurvEw7wNpxLFgjVvBLMta43niEYOy0CJ4ntcYSbx6bugRUTQeFb4BR/WanEL1o3aQgHuVLHQaB6tOqg==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
+      "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
       "dev": true,
       "requires": {
         "arr-diff": "4.0.0",
         "array-unique": "0.3.2",
-        "define-property": "1.0.0",
-        "extend-shallow": "2.0.1",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
         "fragment-cache": "0.2.1",
-        "is-odd": "1.0.0",
-        "kind-of": "5.1.0",
+        "is-odd": "2.0.0",
+        "is-windows": "1.0.2",
+        "kind-of": "6.0.2",
         "object.pick": "1.3.0",
-        "regex-not": "1.0.0",
+        "regex-not": "1.0.2",
         "snapdragon": "0.8.1",
         "to-regex": "3.0.1"
       },
@@ -7654,10 +7786,35 @@
           "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
           "dev": true
         },
+        "extend-shallow": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+          "dev": true,
+          "requires": {
+            "assign-symbols": "1.0.0",
+            "is-extendable": "1.0.1"
+          }
+        },
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "2.0.4"
+          }
+        },
+        "is-windows": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+          "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+          "dev": true
+        },
         "kind-of": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }
@@ -8039,6 +8196,27 @@
         }
       }
     },
+    "object.map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object.map/-/object.map-1.0.1.tgz",
+      "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
+      "dev": true,
+      "requires": {
+        "for-own": "1.0.0",
+        "make-iterator": "1.0.0"
+      },
+      "dependencies": {
+        "for-own": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+          "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+          "dev": true,
+          "requires": {
+            "for-in": "1.0.2"
+          }
+        }
+      }
+    },
     "object.omit": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
@@ -8248,7 +8426,7 @@
         "handlebars": "4.0.11",
         "highlight.js": "8.9.1",
         "js-yaml": "3.10.0",
-        "marked": "0.3.6",
+        "marked": "0.3.16",
         "nopt": "4.0.1",
         "slash": "1.0.0",
         "strip-bom": "2.0.0",
@@ -8915,12 +9093,34 @@
       }
     },
     "regex-not": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.0.tgz",
-      "integrity": "sha1-Qvg+OXcWIt+CawKvF2Ul1qXxV/k=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1"
+        "extend-shallow": "3.0.2",
+        "safe-regex": "1.1.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+          "dev": true,
+          "requires": {
+            "assign-symbols": "1.0.0",
+            "is-extendable": "1.0.1"
+          }
+        },
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "2.0.4"
+          }
+        }
       }
     },
     "regexpu-core": {
@@ -9029,7 +9229,7 @@
           "dev": true,
           "requires": {
             "is-relative": "1.0.0",
-            "is-windows": "1.0.1"
+            "is-windows": "1.0.2"
           }
         },
         "is-relative": {
@@ -9051,9 +9251,9 @@
           }
         },
         "is-windows": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.1.tgz",
-          "integrity": "sha1-MQ23D3QtJZoWo2kgK1GvhCMzENk=",
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+          "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
           "dev": true
         }
       }
@@ -9169,6 +9369,12 @@
         "minimatch": "3.0.4"
       }
     },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true
+    },
     "rewrite-ext": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/rewrite-ext/-/rewrite-ext-0.2.0.tgz",
@@ -9233,6 +9439,15 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
       "dev": true
+    },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "dev": true,
+      "requires": {
+        "ret": "0.1.15"
+      }
     },
     "sass-graph": {
       "version": "2.2.4",
@@ -9706,6 +9921,15 @@
         "snapdragon-util": "3.0.1"
       },
       "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "1.0.2"
+          }
+        },
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
@@ -10182,7 +10406,7 @@
       "requires": {
         "handlebars": "4.0.11",
         "highlight.js": "8.9.1",
-        "marked": "0.3.6",
+        "marked": "0.3.16",
         "string-template": "0.2.1"
       }
     },
@@ -10434,7 +10658,7 @@
       "requires": {
         "define-property": "0.2.5",
         "extend-shallow": "2.0.1",
-        "regex-not": "1.0.0"
+        "regex-not": "1.0.2"
       },
       "dependencies": {
         "define-property": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "RBMFieldHelpers",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "authors": [
     "Joel Worsham <joel@realbigmarketing.com>",
     "Eric Defore <eric@realbigmarketing.com>"

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "gulp-uglify": "^3.0.0",
     "gulp-zip": "^4.0.0",
     "js-yaml": "^3.4.6",
+    "marked": "^0.3.9",
     "panini": "^1.3.0",
     "rimraf": "^2.4.3",
     "style-sherpa": "^1.0.0",

--- a/rbm-field-helpers.php
+++ b/rbm-field-helpers.php
@@ -9,7 +9,7 @@ defined( 'ABSPATH' ) || die();
 
 if ( ! class_exists( 'RBM_FieldHelpers' ) ) {
 
-	define( 'RBM_FIELD_HELPERS_VER', '1.4.3' );
+	define( 'RBM_FIELD_HELPERS_VER', '1.4.4' );
 	
 	if ( strpos( __FILE__, WP_PLUGIN_DIR ) !== false ) {
 	


### PR DESCRIPTION
Fixes #45 

I noticed some PHP errors and some JavaScript-localized values being `null`. This fixes them :+1:

For `do_field_repeater()`'s `setup_data()` method call, it has to read the l10n data from indices _without_ the appended `_text`. I figure this is not what you intended originally since the JavaScript reads from it with `_text` appended, but the Field View for Repeaters reads from it without `_text`. 

So, I just made it work ¯\\\_(ツ)_/¯

I also fixed the dumb "vuln" error real quickly since it is just adding a specific version of `marked` to `package.json`. May be worth a `rm -rf node_modules && npm i` to ensure all your Webpack stuff is still working correctly, but it ought to be fine.