### PR TITLE
Automatically Enqueue Scripts for Datepicker, Timepicker, and Datetimepicker fields

### DIFF
--- a/core/fields/class-rbm-fh-field-datepicker.php
+++ b/core/fields/class-rbm-fh-field-datepicker.php
@@ -63,6 +63,8 @@ class RBM_FH_Field_DatePicker extends RBM_FH_Field {
 	 * @param array $args Field arguments.
 	 */
 	public static function field( $name, $value, $args = array() ) {
+		
+		wp_enqueue_script( 'jquery-ui-datepicker' );
 
 		// Get preview format
 		$args['preview'] = date( $args['format'], strtotime( $value ? $value : $args['default'] ) );

--- a/core/fields/class-rbm-fh-field-datetimepicker.php
+++ b/core/fields/class-rbm-fh-field-datetimepicker.php
@@ -67,6 +67,9 @@ class RBM_FH_Field_DateTimePicker extends RBM_FH_Field {
 	 * @param array $args Field arguments.
 	 */
 	public static function field( $name, $value, $args = array() ) {
+		
+		wp_enqueue_script( 'rbm-fh-jquery-ui-datetimepicker' );
+		wp_enqueue_style( 'rbm-fh-jquery-ui-datetimepicker' );
 
 		// Get preview format
 		$args['preview'] = date( $args['format'], strtotime( $value ? $value : $args['default'] ) );

--- a/core/fields/class-rbm-fh-field-timepicker.php
+++ b/core/fields/class-rbm-fh-field-timepicker.php
@@ -66,6 +66,9 @@ class RBM_FH_Field_TimePicker extends RBM_FH_Field {
 	 * @param array $args Field arguments.
 	 */
 	public static function field( $name, $value, $args = array() ) {
+		
+		wp_enqueue_script( 'rbm-fh-jquery-ui-datetimepicker' );
+		wp_enqueue_style( 'rbm-fh-jquery-ui-datetimepicker' );
 
 		// Get preview format
 		$args['preview'] = date( $args['format'], strtotime( $value ? $value : $args['default'] ) );

--- a/rbm-field-helpers.php
+++ b/rbm-field-helpers.php
@@ -246,19 +246,6 @@ if ( ! class_exists( 'RBM_FieldHelpers' ) ) {
 			wp_enqueue_script( 'rbm-fh-jquery-repeater' );
 
 			/**
-			 * Load or don't load the Date/Time Picker scripts.
-			 *
-			 * @since 1.4.0
-			 */
-			$load_datetimepicker = apply_filters( 'rbm_fieldhelpers_load_datetimepicker', false );
-
-			if ( $load_datetimepicker ) {
-
-				wp_enqueue_script( 'rbm-fh-jquery-ui-datetimepicker' );
-				wp_enqueue_style( 'rbm-fh-jquery-ui-datetimepicker' );
-			}
-
-			/**
 			 * Load or don't load the Select2 scripts.
 			 *
 			 * @since 1.4.0


### PR DESCRIPTION
This one is a little tricky, only because it is removing a Filter. But that shouldn't matter since running code on non-existent Actions and Filters doesn't harm anything.

With RBM FH v1.4.0 (First release of the new submodule method), a Filter called `rbm_fieldhelpers_load_datetimepicker` was introduced to Enable loading these scripts automatically whether a necessary Field was being used or not.

Now these Fields instead enqueue the necessary scripts only when actually needed, similar to the WYSIWYG option for Textarea Fields. They'll only enqueue once, so there's no danger in doing it this way.