### PR TITLE
Fixes errors with Datetimepicker

### DIFF
--- a/assets/dist/css/rbm-field-helpers-admin.min.css
+++ b/assets/dist/css/rbm-field-helpers-admin.min.css
@@ -1,1 +1,645 @@
-.fieldhelpers-fieldset{border:1px solid #ddd;padding:.5em}.fieldhelpers-col{-webkit-box-sizing:border-box;box-sizing:border-box;padding:.5em;float:left}.fieldhelpers-col-1{-webkit-box-sizing:border-box;box-sizing:border-box;padding:.5em;float:left;width:100%}@media only screen and (max-width:640px){.fieldhelpers-col-1{width:100%}}.fieldhelpers-col-2{-webkit-box-sizing:border-box;box-sizing:border-box;padding:.5em;float:left;width:50%}@media only screen and (max-width:640px){.fieldhelpers-col-2{width:100%}}.fieldhelpers-col-3{-webkit-box-sizing:border-box;box-sizing:border-box;padding:.5em;float:left;width:33.33333%}@media only screen and (max-width:640px){.fieldhelpers-col-3{width:100%}}.fieldhelpers-col-4{-webkit-box-sizing:border-box;box-sizing:border-box;padding:.5em;float:left;width:25%}@media only screen and (max-width:640px){.fieldhelpers-col-4{width:100%}}.fieldhelpers-col-5{-webkit-box-sizing:border-box;box-sizing:border-box;padding:.5em;float:left;width:20%}@media only screen and (max-width:640px){.fieldhelpers-col-5{width:100%}}.fieldhelpers-field{margin-bottom:1em}.fieldhelpers-field-header{margin-bottom:.5em}.fieldhelpers-field-checkbox-container{display:inline-block;border:1px solid #dfdfdf;background:#fff;width:300px;max-width:100%}.fieldhelpers-field-checkbox-row{position:relative;cursor:pointer;-webkit-transition:background 150ms;transition:background 150ms;line-height:30px}.fieldhelpers-field-checkbox-row:hover{background:#f2f2f2;-webkit-transition:background 0s;transition:background 0s}.fieldhelpers-field-checkbox-row:after{content:'';clear:both;display:table}.fieldhelpers-field-checkbox-row:not(:last-of-type){border-bottom:1px solid #dfdfdf}.fieldhelpers-field-checkbox-row.fieldhelpers-field-checkbox-row-active{background:#007ab1}.fieldhelpers-field-checkbox-row.fieldhelpers-field-checkbox-row-active:hover{background:#006898}.fieldhelpers-field-checkbox-row.fieldhelpers-field-checkbox-row-active .fieldhelpers-field-checkbox-label{color:#fff}.fieldhelpers-field-checkbox-row .fieldhelpers-field-checkbox-input-container{width:15%;float:left;-webkit-box-sizing:border-box;box-sizing:border-box;line-height:30px;text-align:center}.fieldhelpers-field-checkbox-row input[type=checkbox]{margin:0 .5em}.fieldhelpers-field-checkbox-row .fieldhelpers-field-checkbox-label{display:block;float:left;width:85%;font-weight:700;padding:0 .5em;border-left:1px solid #dfdfdf;line-height:30px;-webkit-box-sizing:border-box;box-sizing:border-box}.fieldhelpers-field-colorpicker{position:relative}.fieldhelpers-field-colorpicker .wp-picker-holder{position:absolute;left:0;top:100%;-webkit-box-shadow:5px 5px 30px rgba(0,0,0,.5);box-shadow:5px 5px 30px rgba(0,0,0,.5);z-index:100}.ui-datepicker{padding:0;margin:0;border-radius:0;background-color:#fff;border:1px solid #dfdfdf;border-top:none;-webkit-box-shadow:0 3px 6px rgba(0,0,0,.075);box-shadow:0 3px 6px rgba(0,0,0,.075);min-width:17em;width:auto}.ui-datepicker *{padding:0;font-family:"Open Sans",sans-serif;border-radius:0}.ui-datepicker table{font-size:13px;margin:0;border:none;border-collapse:collapse}.ui-datepicker .ui-datepicker-header,.ui-datepicker .ui-widget-header{background-image:none;border:none;color:#fff;font-weight:400}.ui-datepicker .ui-datepicker-header .ui-state-hover{background:0 0;border-color:transparent;cursor:pointer}.ui-datepicker .ui-datepicker-title{margin:0;padding:10px 0;color:#fff;font-size:14px;line-height:14px;text-align:center}.ui-datepicker .ui-datepicker-next,.ui-datepicker .ui-datepicker-prev{position:relative;top:0;height:34px;width:34px}.ui-datepicker .ui-state-hover.ui-datepicker-next,.ui-datepicker .ui-state-hover.ui-datepicker-prev{border:none}.ui-datepicker .ui-datepicker-prev,.ui-datepicker .ui-datepicker-prev-hover{left:0}.ui-datepicker .ui-datepicker-next,.ui-datepicker .ui-datepicker-next-hover{right:0}.ui-datepicker .ui-datepicker-next span,.ui-datepicker .ui-datepicker-prev span{display:none}.ui-datepicker .ui-datepicker-prev{float:left}.ui-datepicker .ui-datepicker-next{float:right}.ui-datepicker .ui-datepicker-next:before,.ui-datepicker .ui-datepicker-prev:before{font:normal 20px/34px dashicons;padding-left:7px;color:#fff;speak:none;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;width:34px;height:34px}.ui-datepicker .ui-datepicker-prev:before{content:'\f341'}.ui-datepicker .ui-datepicker-next:before{content:'\f345'}.ui-datepicker .ui-datepicker-next-hover:before,.ui-datepicker .ui-datepicker-prev-hover:before{opacity:.7}.ui-datepicker select.ui-datepicker-month,.ui-datepicker select.ui-datepicker-year{width:33%}.ui-datepicker thead{color:#fff;font-weight:600}.ui-datepicker th{padding:10px}.ui-datepicker td{padding:0;border:1px solid #f4f4f4}.ui-datepicker td.ui-datepicker-other-month{border:transparent}.ui-datepicker td .ui-state-default{background:0 0;border:none;text-align:center;text-decoration:none;width:auto;display:block;padding:5px 10px;font-weight:400;color:#444}.ui-datepicker td.ui-state-disabled .ui-state-default{opacity:.5}.ui-datepicker .ui-datepicker-header,.ui-datepicker .ui-widget-header{background:#52accc}.ui-datepicker thead{background:#096484}.ui-datepicker td.ui-datepicker-week-end{background-color:#f4f4f4;border:1px solid #f4f4f4}.ui-datepicker td.ui-datepicker-today{background-color:#4796b3}.ui-datepicker td.ui-datepicker-current-day{background:#4796b3;color:#fff}.ui-datepicker td a.ui-state-default{color:inherit}.ui-datepicker td a.ui-state-hover{background:#096484;color:#fff}.fieldhelpers-field-hidden{display:none}.fieldhelpers-field-list .fieldhelpers-field-list-item{border:1px solid #ddd;background-color:#fff;padding:.5em;margin-bottom:.5em;cursor:move}.fieldhelpers-field-list .fieldhelpers-field-list-item-handle{color:#bbb}.fieldhelpers-media-uploader .media-url{display:block;width:100%;word-break:break-all;-webkit-box-sizing:border-box;box-sizing:border-box}.fieldhelpers-media-uploader .image-preview{max-width:100%}.fieldhelpers-field-number .fieldhelpers-field-number-container{width:100px}.fieldhelpers-field-number .fieldhelpers-field-number-container[data-postfix]{position:relative}.fieldhelpers-field-number .fieldhelpers-field-number-container[data-postfix]:after{content:attr(data-postfix);position:absolute;right:calc(20px + .5em);top:50%;color:#aaa;-webkit-transform:translateY(-50%);-ms-transform:translateY(-50%);transform:translateY(-50%)}.fieldhelpers-field-number input[type=text].fieldhelpers-field-input{height:40px;line-height:40px;width:80px;padding:0;margin:0;float:left;text-align:center}.fieldhelpers-field-number .fieldhelpers-field-number-decrease,.fieldhelpers-field-number .fieldhelpers-field-number-increase{display:block;height:20px;width:20px;line-height:20px;padding:0;font-size:14px;color:#fff;background:#007ab1;border:1px solid #006898;-webkit-box-shadow:0 1px 0 #006898;box-shadow:0 1px 0 #006898;outline:0;border-radius:0;cursor:pointer}.fieldhelpers-field-number .fieldhelpers-field-number-decrease:hover,.fieldhelpers-field-number .fieldhelpers-field-number-increase:hover{color:#fff;background:#008ccb;border-color:#007ab1;-webkit-box-shadow:0 1px 0 #007ab1;box-shadow:0 1px 0 #007ab1}.fieldhelpers-field-number .fieldhelpers-field-number-decrease:active,.fieldhelpers-field-number .fieldhelpers-field-number-increase:active{-webkit-transform:translateY(1px);-ms-transform:translateY(1px);transform:translateY(1px)}.fieldhelpers-field-number .fieldhelpers-field-number-decrease .dashicons,.fieldhelpers-field-number .fieldhelpers-field-number-increase .dashicons{font-size:inherit;line-height:inherit;width:auto;height:auto}.fieldhelpers-field-number .fieldhelpers-field-number-increase{border-top-left-radius:3px;border-top-right-radius:3px;border-bottom-width:0}.fieldhelpers-field-number .fieldhelpers-field-number-decrease{border-bottom-left-radius:3px;border-bottom-right-radius:3px}.fieldhelpers-field-radio-container{display:inline-block;border:1px solid #dfdfdf;background:#fff;width:300px;max-width:100%}.fieldhelpers-field-radio-row{position:relative;cursor:pointer;-webkit-transition:background 150ms;transition:background 150ms;height:30px}.fieldhelpers-field-radio-row:hover{background:#f2f2f2;-webkit-transition:background 0s;transition:background 0s}.fieldhelpers-field-radio-row:after{content:'';clear:both;display:table}.fieldhelpers-field-radio-row:not(:last-of-type){border-bottom:1px solid #dfdfdf}.fieldhelpers-field-radio-row.fieldhelpers-field-radio-row-active{background:#007ab1}.fieldhelpers-field-radio-row.fieldhelpers-field-radio-row-active:hover{background:#006898}.fieldhelpers-field-radio-row.fieldhelpers-field-radio-row-active .fieldhelpers-field-radio-label{color:#fff}.fieldhelpers-field-radio-row .fieldhelpers-field-radio-input-container{width:15%;float:left;-webkit-box-sizing:border-box;box-sizing:border-box;line-height:30px;text-align:center}.fieldhelpers-field-radio-row input[type=radio]{margin:0 .5em}.fieldhelpers-field-radio-row .fieldhelpers-field-radio-label{display:block;float:left;width:85%;font-weight:700;padding:0 .5em;border-left:1px solid #dfdfdf;height:30px;line-height:30px;-webkit-box-sizing:border-box;box-sizing:border-box}.fieldhelpers-field-repeater-label{font-weight:700}.fieldhelpers-field-repeater-list .fieldhelpers-sortable-placeholder{border:3px dashed #ddd}.fieldhelpers-field-repeater-row{padding:.5em;margin:.5em 0;border:1px solid #ddd;background:#fff}.fieldhelpers-field-repeater-row:before{content:'';display:table;clear:both}.fieldhelpers-field-repeater-row.ui-sortable-helper{opacity:.5}.fieldhelpers-field-repeater-row .fieldhelpers-field-repeater-handle{height:20px;cursor:move;margin-bottom:10px;background-image:-webkit-repeating-radial-gradient(center center,rgba(0,0,0,.2),rgba(0,0,0,.2) 1px,transparent 1px,transparent 100%);background-image:repeating-radial-gradient(center center,rgba(0,0,0,.2),rgba(0,0,0,.2) 1px,transparent 1px,transparent 100%);background-size:3px 3px}.fieldhelpers-field-repeater-collapsable .fieldhelpers-field-repeater-content{display:none}.fieldhelpers-field-repeater-collapsable .fieldhelpers-field-repeater-header-interior{padding:0 .5em 0 .5em}.fieldhelpers-field-repeater-collapsable .fieldhelpers-field-repeater-header-interior .fieldhelpers-field-repeater-delete-button{float:right}.fieldhelpers-field-repeater-collapsable .fieldhelpers-field-repeater-collapsable-handle{cursor:pointer}.fieldhelpers-field-repeater-collapsable .fieldhelpers-field-repeater-row.opened .fieldhelpers-field-repeater-collapsable-collapse-icon{-webkit-transform:rotate(180deg);-ms-transform:rotate(180deg);transform:rotate(180deg)}.fieldhelpers-field-repeater-collapsable .fieldhelpers-field-repeater-collapsable-collapse-icon{-webkit-transition:-webkit-transform .3s ease-in 0s;transition:-webkit-transform .3s ease-in 0s;transition:transform .3s ease-in 0s;transition:transform .3s ease-in 0s,-webkit-transform .3s ease-in 0s}.fieldhelpers-field-repeater-collapsable .fieldhelpers-field-repeater-collapsable-collapse-icon:hover{cursor:pointer}.select2-container--default .fieldhelpers-select2.select2-selection--multiple.select2-selection,.select2-container--default .fieldhelpers-select2.select2-selection--single.select2-selection{border-radius:0;border:1px solid #ddd;-webkit-box-shadow:inset 0 1px 2px rgba(0,0,0,.07);box-shadow:inset 0 1px 2px rgba(0,0,0,.07);outline:0;margin:1px;height:auto}.select2-container--default .fieldhelpers-select2.select2-selection--multiple .select2-selection__rendered,.select2-container--default .fieldhelpers-select2.select2-selection--single .select2-selection__rendered{line-height:inherit;padding:3px 5px;font-size:14px}.select2-container--default .fieldhelpers-select2.select2-selection--multiple .select2-search,.select2-container--default .fieldhelpers-select2.select2-selection--single .select2-search{margin-bottom:0}.select2-container--default .fieldhelpers-select2.select2-selection--multiple .select2-selection__choice,.select2-container--default .fieldhelpers-select2.select2-selection--single .select2-selection__choice{border-radius:0}.select2-container--default .fieldhelpers-select2.select2-selection--multiple .select2-selection__clear,.select2-container--default .fieldhelpers-select2.select2-selection--single .select2-selection__clear{margin-right:15px}.select2-container--default .fieldhelpers-select2.select2-dropdown{border-radius:0;border:1px solid #ddd;-webkit-box-shadow:5px 5px 40px rgba(0,0,0,.3);box-shadow:5px 5px 40px rgba(0,0,0,.3)}.select2-container--default .fieldhelpers-select2.select2-dropdown .select2-results__option--highlighted[aria-selected]{background-color:#007ab1}.select2-container--default .fieldhelpers-select2.select2-dropdown .select2-results__option{margin-bottom:0}.fieldhelpers-field-table .fieldhelpers-field-table-loading{text-align:center}.fieldhelpers-field-table .fieldhelpers-field-table-loading .spinner{float:none;display:inline-block}.fieldhelpers-field-table table{width:100%;border-collapse:collapse}.fieldhelpers-field-table td,.fieldhelpers-field-table th{padding:5px}.fieldhelpers-field-table thead input[type=text]{background:#fff78a}.fieldhelpers-field-table input[type=text]{width:100%}.fieldhelpers-field-table .fieldhelpers-field-table-delete-columns{text-align:center}.fieldhelpers-field-toggle-container{position:relative;display:inline-block;width:60px;height:34px}.fieldhelpers-field-toggle-container.checked .fieldhelpers-field-toggle-slider{background-color:#007ab1}.fieldhelpers-field-toggle-container.checked .fieldhelpers-field-toggle-slider:before{-webkit-transform:translateX(26px);-ms-transform:translateX(26px);transform:translateX(26px)}.fieldhelpers-field-toggle-container .fieldhelpers-field-toggle-slider{position:absolute;cursor:pointer;top:0;left:0;right:0;bottom:0;background-color:#ccc;-webkit-transition:-webkit-transform .3s;transition:-webkit-transform .3s;transition:transform .3s;transition:transform .3s,-webkit-transform .3s}.fieldhelpers-field-toggle-container .fieldhelpers-field-toggle-slider:before{position:absolute;content:"";height:26px;width:26px;left:4px;bottom:4px;background-color:#fff;-webkit-transition:-webkit-transform .3s;transition:-webkit-transform .3s;transition:transform .3s;transition:transform .3s,-webkit-transform .3s}.fieldhelpers-field-wysiwyg-label{font-weight:700}.fieldhelpers-field-tip{position:relative;display:inline-block}.fieldhelpers-field-tip.fieldhelpers-field-tip-align-left .fieldhelpers-field-tip-text{left:-10px}.fieldhelpers-field-tip.fieldhelpers-field-tip-align-left .fieldhelpers-field-tip-text:before{left:10px}.fieldhelpers-field-tip.fieldhelpers-field-tip-align-right .fieldhelpers-field-tip-text{right:-10px}.fieldhelpers-field-tip.fieldhelpers-field-tip-align-right .fieldhelpers-field-tip-text:before{right:10px}.fieldhelpers-field-tip:hover .fieldhelpers-field-tip-text{visibility:visible;opacity:1;-webkit-transform:translateY(0);-ms-transform:translateY(0);transform:translateY(0)}.fieldhelpers-field-tip:hover .fieldhelpers-field-tip-toggle{color:#007ab1}.fieldhelpers-field-tip .fieldhelpers-field-tip-toggle{cursor:pointer;-webkit-transition:color .3s;transition:color .3s}.fieldhelpers-field-tip .fieldhelpers-field-tip-text{position:absolute;visibility:hidden;opacity:0;top:100%;margin-top:15px;background:#007ab1;color:#fff;padding:1em;width:300px;text-align:left;-webkit-box-shadow:5px 5px 40px rgba(0,0,0,.3);box-shadow:5px 5px 40px rgba(0,0,0,.3);-webkit-transform:translateY(10px);-ms-transform:translateY(10px);transform:translateY(10px);-webkit-transition:visibility .3s,opacity .3s,-webkit-transform .3s;transition:visibility .3s,opacity .3s,-webkit-transform .3s;transition:visibility .3s,opacity .3s,transform .3s;transition:visibility .3s,opacity .3s,transform .3s,-webkit-transform .3s;z-index:100}.fieldhelpers-field-tip .fieldhelpers-field-tip-text:before{content:'';position:absolute;bottom:100%;width:0;height:0;border-style:solid;border-width:0 10px 10px 10px;border-color:transparent transparent #007ab1 transparent}.fieldhelpers-field-tip .fieldhelpers-field-tip-text:after{content:'';position:absolute;bottom:100%;left:0;width:100%;height:15px}.fieldhelpers-field-tip .fieldhelpers-field-tip-text a{color:inherit!important;text-decoration:underline}
+.fieldhelpers-fieldset {
+  border: 1px solid #ddd;
+  padding: 0.5em; }
+
+.fieldhelpers-col {
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  padding: 0.5em;
+  float: left; }
+
+.fieldhelpers-col-1 {
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  padding: 0.5em;
+  float: left;
+  width: 100%; }
+  @media only screen and (max-width: 640px) {
+    .fieldhelpers-col-1 {
+      width: 100%; } }
+
+.fieldhelpers-col-2 {
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  padding: 0.5em;
+  float: left;
+  width: 50%; }
+  @media only screen and (max-width: 640px) {
+    .fieldhelpers-col-2 {
+      width: 100%; } }
+
+.fieldhelpers-col-3 {
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  padding: 0.5em;
+  float: left;
+  width: 33.33333%; }
+  @media only screen and (max-width: 640px) {
+    .fieldhelpers-col-3 {
+      width: 100%; } }
+
+.fieldhelpers-col-4 {
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  padding: 0.5em;
+  float: left;
+  width: 25%; }
+  @media only screen and (max-width: 640px) {
+    .fieldhelpers-col-4 {
+      width: 100%; } }
+
+.fieldhelpers-col-5 {
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  padding: 0.5em;
+  float: left;
+  width: 20%; }
+  @media only screen and (max-width: 640px) {
+    .fieldhelpers-col-5 {
+      width: 100%; } }
+
+.fieldhelpers-field {
+  margin-bottom: 1em; }
+
+.fieldhelpers-field-header {
+  margin-bottom: 0.5em; }
+
+.fieldhelpers-field-checkbox-container {
+  display: inline-block;
+  border: 1px solid #DFDFDF;
+  background: #fff;
+  width: 300px;
+  max-width: 100%; }
+
+.fieldhelpers-field-checkbox-row {
+  position: relative;
+  cursor: pointer;
+  -webkit-transition: background 150ms;
+  transition: background 150ms;
+  line-height: 30px; }
+  .fieldhelpers-field-checkbox-row:hover {
+    background: #f2f2f2;
+    -webkit-transition: background 0s;
+    transition: background 0s; }
+  .fieldhelpers-field-checkbox-row:after {
+    content: '';
+    clear: both;
+    display: table; }
+  .fieldhelpers-field-checkbox-row:not(:last-of-type) {
+    border-bottom: 1px solid #DFDFDF; }
+  .fieldhelpers-field-checkbox-row.fieldhelpers-field-checkbox-row-active {
+    background: #007AB1; }
+    .fieldhelpers-field-checkbox-row.fieldhelpers-field-checkbox-row-active:hover {
+      background: #006898; }
+    .fieldhelpers-field-checkbox-row.fieldhelpers-field-checkbox-row-active .fieldhelpers-field-checkbox-label {
+      color: #fff; }
+  .fieldhelpers-field-checkbox-row .fieldhelpers-field-checkbox-input-container {
+    width: 15%;
+    float: left;
+    -webkit-box-sizing: border-box;
+            box-sizing: border-box;
+    line-height: 30px;
+    text-align: center; }
+  .fieldhelpers-field-checkbox-row input[type="checkbox"] {
+    margin: 0 0.5em; }
+  .fieldhelpers-field-checkbox-row .fieldhelpers-field-checkbox-label {
+    display: block;
+    float: left;
+    width: 85%;
+    font-weight: bold;
+    padding: 0 0.5em;
+    border-left: 1px solid #DFDFDF;
+    line-height: 30px;
+    -webkit-box-sizing: border-box;
+            box-sizing: border-box; }
+
+.fieldhelpers-field-colorpicker {
+  position: relative; }
+  .fieldhelpers-field-colorpicker .wp-picker-holder {
+    position: absolute;
+    left: 0;
+    top: 100%;
+    -webkit-box-shadow: 5px 5px 30px rgba(0, 0, 0, 0.5);
+            box-shadow: 5px 5px 30px rgba(0, 0, 0, 0.5);
+    z-index: 100; }
+
+/* Date Picker Default Styles */
+.ui-datepicker {
+  padding: 0;
+  margin: 0;
+  border-radius: 0;
+  background-color: #fff;
+  border: 1px solid #dfdfdf;
+  border-top: none;
+  -webkit-box-shadow: 0 3px 6px rgba(0, 0, 0, 0.075);
+  box-shadow: 0 3px 6px rgba(0, 0, 0, 0.075);
+  min-width: 17em;
+  width: auto; }
+
+.ui-datepicker * {
+  padding: 0;
+  font-family: "Open Sans", sans-serif;
+  border-radius: 0; }
+
+.ui-datepicker table {
+  font-size: 13px;
+  margin: 0;
+  border: none;
+  border-collapse: collapse; }
+
+.ui-datepicker .ui-widget-header,
+.ui-datepicker .ui-datepicker-header {
+  background-image: none;
+  border: none;
+  color: #fff;
+  font-weight: normal; }
+
+.ui-datepicker .ui-datepicker-header .ui-state-hover {
+  background: transparent;
+  border-color: transparent;
+  cursor: pointer; }
+
+.ui-datepicker .ui-datepicker-title {
+  margin: 0;
+  padding: 10px 0;
+  color: #fff;
+  font-size: 14px;
+  line-height: 14px;
+  text-align: center; }
+
+.ui-datepicker .ui-datepicker-prev,
+.ui-datepicker .ui-datepicker-next {
+  position: relative;
+  top: 0;
+  height: 34px;
+  width: 34px; }
+
+.ui-datepicker .ui-state-hover.ui-datepicker-prev,
+.ui-datepicker .ui-state-hover.ui-datepicker-next {
+  border: none; }
+
+.ui-datepicker .ui-datepicker-prev,
+.ui-datepicker .ui-datepicker-prev-hover {
+  left: 0; }
+
+.ui-datepicker .ui-datepicker-next,
+.ui-datepicker .ui-datepicker-next-hover {
+  right: 0; }
+
+.ui-datepicker .ui-datepicker-next span,
+.ui-datepicker .ui-datepicker-prev span {
+  display: none; }
+
+.ui-datepicker .ui-datepicker-prev {
+  float: left; }
+
+.ui-datepicker .ui-datepicker-next {
+  float: right; }
+
+.ui-datepicker .ui-datepicker-prev:before,
+.ui-datepicker .ui-datepicker-next:before {
+  font: normal 20px/34px 'dashicons';
+  padding-left: 7px;
+  color: #fff;
+  speak: none;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  width: 34px;
+  height: 34px; }
+
+.ui-datepicker .ui-datepicker-prev:before {
+  content: '\f341'; }
+
+.ui-datepicker .ui-datepicker-next:before {
+  content: '\f345'; }
+
+.ui-datepicker .ui-datepicker-prev-hover:before,
+.ui-datepicker .ui-datepicker-next-hover:before {
+  opacity: 0.7; }
+
+.ui-datepicker select.ui-datepicker-month,
+.ui-datepicker select.ui-datepicker-year {
+  width: 33%; }
+
+.ui-datepicker thead {
+  color: #fff;
+  font-weight: 600; }
+
+.ui-datepicker th {
+  padding: 10px; }
+
+.ui-datepicker td {
+  padding: 0;
+  border: 1px solid #f4f4f4; }
+
+.ui-datepicker td.ui-datepicker-other-month {
+  border: transparent; }
+
+.ui-datepicker td .ui-state-default {
+  background: transparent;
+  border: none;
+  text-align: center;
+  text-decoration: none;
+  width: auto;
+  display: block;
+  padding: 5px 10px;
+  font-weight: normal;
+  color: #444; }
+
+.ui-datepicker td.ui-state-disabled .ui-state-default {
+  opacity: 0.5; }
+
+.ui-datepicker .ui-widget-header, .ui-datepicker .ui-datepicker-header {
+  background: #52accc; }
+
+.ui-datepicker thead {
+  background: #096484; }
+
+.ui-datepicker td.ui-datepicker-week-end {
+  background-color: #f4f4f4;
+  border: 1px solid #f4f4f4; }
+
+.ui-datepicker td.ui-datepicker-today {
+  background-color: #4796b3; }
+
+.ui-datepicker td.ui-datepicker-current-day {
+  background: #4796b3;
+  color: #fff; }
+
+.ui-datepicker td a.ui-state-default {
+  color: inherit; }
+
+.ui-datepicker td a.ui-state-hover {
+  background: #096484;
+  color: #fff; }
+
+.ui-datepicker-buttonpane {
+  padding: 6px; }
+  .ui-datepicker-buttonpane .ui-datepicker-current, .ui-datepicker-buttonpane .ui-datepicker-close {
+    color: #555;
+    border-color: #cccccc;
+    background: #f7f7f7;
+    -webkit-box-shadow: 0 1px 0 #cccccc;
+            box-shadow: 0 1px 0 #cccccc;
+    vertical-align: top;
+    display: inline-block;
+    text-decoration: none;
+    font-size: 13px;
+    line-height: 26px;
+    height: 28px;
+    margin: 0;
+    padding: 0 10px 1px;
+    cursor: pointer;
+    border-width: 1px;
+    border-style: solid;
+    -webkit-appearance: none;
+    border-radius: 3px;
+    white-space: nowrap;
+    -webkit-box-sizing: border-box;
+            box-sizing: border-box;
+    margin-right: 6px; }
+
+.fieldhelpers-field-hidden {
+  display: none; }
+
+.fieldhelpers-field-list .fieldhelpers-field-list-item {
+  border: 1px solid #ddd;
+  background-color: #fff;
+  padding: 0.5em;
+  margin-bottom: 0.5em;
+  cursor: move; }
+
+.fieldhelpers-field-list .fieldhelpers-field-list-item-handle {
+  color: #bbb; }
+
+.fieldhelpers-media-uploader .media-url {
+  display: block;
+  width: 100%;
+  word-break: break-all;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box; }
+
+.fieldhelpers-media-uploader .image-preview {
+  max-width: 100%; }
+
+.fieldhelpers-field-number .fieldhelpers-field-number-container {
+  width: 100px; }
+  .fieldhelpers-field-number .fieldhelpers-field-number-container[data-postfix] {
+    position: relative; }
+    .fieldhelpers-field-number .fieldhelpers-field-number-container[data-postfix]:after {
+      content: attr(data-postfix);
+      position: absolute;
+      right: calc(20px + 0.5em);
+      top: 50%;
+      color: #aaa;
+      -webkit-transform: translateY(-50%);
+          -ms-transform: translateY(-50%);
+              transform: translateY(-50%); }
+
+.fieldhelpers-field-number input[type="text"].fieldhelpers-field-input {
+  height: 40px;
+  line-height: 40px;
+  width: 80px;
+  padding: 0;
+  margin: 0;
+  float: left;
+  text-align: center; }
+
+.fieldhelpers-field-number .fieldhelpers-field-number-increase, .fieldhelpers-field-number .fieldhelpers-field-number-decrease {
+  display: block;
+  height: 20px;
+  width: 20px;
+  line-height: 20px;
+  padding: 0;
+  font-size: 14px;
+  color: #fff;
+  background: #007AB1;
+  border: 1px solid #006898;
+  -webkit-box-shadow: 0 1px 0 #006898;
+          box-shadow: 0 1px 0 #006898;
+  outline: none;
+  border-radius: 0;
+  cursor: pointer; }
+  .fieldhelpers-field-number .fieldhelpers-field-number-increase:hover, .fieldhelpers-field-number .fieldhelpers-field-number-decrease:hover {
+    color: #fff;
+    background: #008ccb;
+    border-color: #007AB1;
+    -webkit-box-shadow: 0 1px 0 #007AB1;
+            box-shadow: 0 1px 0 #007AB1; }
+  .fieldhelpers-field-number .fieldhelpers-field-number-increase:active, .fieldhelpers-field-number .fieldhelpers-field-number-decrease:active {
+    -webkit-transform: translateY(1px);
+        -ms-transform: translateY(1px);
+            transform: translateY(1px); }
+  .fieldhelpers-field-number .fieldhelpers-field-number-increase .dashicons, .fieldhelpers-field-number .fieldhelpers-field-number-decrease .dashicons {
+    font-size: inherit;
+    line-height: inherit;
+    width: auto;
+    height: auto; }
+
+.fieldhelpers-field-number .fieldhelpers-field-number-increase {
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
+  border-bottom-width: 0; }
+
+.fieldhelpers-field-number .fieldhelpers-field-number-decrease {
+  border-bottom-left-radius: 3px;
+  border-bottom-right-radius: 3px; }
+
+.fieldhelpers-field-radio-container {
+  display: inline-block;
+  border: 1px solid #DFDFDF;
+  background: #fff;
+  width: 300px;
+  max-width: 100%; }
+
+.fieldhelpers-field-radio-row {
+  position: relative;
+  cursor: pointer;
+  -webkit-transition: background 150ms;
+  transition: background 150ms;
+  height: 30px; }
+  .fieldhelpers-field-radio-row:hover {
+    background: #f2f2f2;
+    -webkit-transition: background 0s;
+    transition: background 0s; }
+  .fieldhelpers-field-radio-row:after {
+    content: '';
+    clear: both;
+    display: table; }
+  .fieldhelpers-field-radio-row:not(:last-of-type) {
+    border-bottom: 1px solid #DFDFDF; }
+  .fieldhelpers-field-radio-row.fieldhelpers-field-radio-row-active {
+    background: #007AB1; }
+    .fieldhelpers-field-radio-row.fieldhelpers-field-radio-row-active:hover {
+      background: #006898; }
+    .fieldhelpers-field-radio-row.fieldhelpers-field-radio-row-active .fieldhelpers-field-radio-label {
+      color: #fff; }
+  .fieldhelpers-field-radio-row .fieldhelpers-field-radio-input-container {
+    width: 15%;
+    float: left;
+    -webkit-box-sizing: border-box;
+            box-sizing: border-box;
+    line-height: 30px;
+    text-align: center; }
+  .fieldhelpers-field-radio-row input[type="radio"] {
+    margin: 0 0.5em; }
+  .fieldhelpers-field-radio-row .fieldhelpers-field-radio-label {
+    display: block;
+    float: left;
+    width: 85%;
+    font-weight: bold;
+    padding: 0 0.5em;
+    border-left: 1px solid #DFDFDF;
+    height: 30px;
+    line-height: 30px;
+    -webkit-box-sizing: border-box;
+            box-sizing: border-box; }
+
+.fieldhelpers-field-repeater-label {
+  font-weight: bold; }
+
+.fieldhelpers-field-repeater-list .fieldhelpers-sortable-placeholder {
+  border: 3px dashed #ddd; }
+
+.fieldhelpers-field-repeater-row {
+  padding: 0.5em;
+  margin: 0.5em 0;
+  border: 1px solid #ddd;
+  background: #fff; }
+  .fieldhelpers-field-repeater-row:before {
+    content: '';
+    display: table;
+    clear: both; }
+  .fieldhelpers-field-repeater-row.ui-sortable-helper {
+    opacity: 0.5; }
+  .fieldhelpers-field-repeater-row .fieldhelpers-field-repeater-handle {
+    height: 20px;
+    cursor: move;
+    margin-bottom: 10px;
+    background-image: -webkit-repeating-radial-gradient(center center, rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.2) 1px, transparent 1px, transparent 100%);
+    background-image: repeating-radial-gradient(center center, rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.2) 1px, transparent 1px, transparent 100%);
+    background-size: 3px 3px; }
+
+.fieldhelpers-field-repeater-collapsable .fieldhelpers-field-repeater-content {
+  display: none; }
+
+.fieldhelpers-field-repeater-collapsable .fieldhelpers-field-repeater-header-interior {
+  padding: 0 0.5em 0 0.5em; }
+  .fieldhelpers-field-repeater-collapsable .fieldhelpers-field-repeater-header-interior .fieldhelpers-field-repeater-delete-button {
+    float: right; }
+
+.fieldhelpers-field-repeater-collapsable .fieldhelpers-field-repeater-collapsable-handle {
+  cursor: pointer; }
+
+.fieldhelpers-field-repeater-collapsable .fieldhelpers-field-repeater-row.opened .fieldhelpers-field-repeater-collapsable-collapse-icon {
+  -webkit-transform: rotate(180deg);
+      -ms-transform: rotate(180deg);
+          transform: rotate(180deg); }
+
+.fieldhelpers-field-repeater-collapsable .fieldhelpers-field-repeater-collapsable-collapse-icon {
+  -webkit-transition: -webkit-transform 300ms ease-in 0s;
+  transition: -webkit-transform 300ms ease-in 0s;
+  transition: transform 300ms ease-in 0s;
+  transition: transform 300ms ease-in 0s, -webkit-transform 300ms ease-in 0s; }
+  .fieldhelpers-field-repeater-collapsable .fieldhelpers-field-repeater-collapsable-collapse-icon:hover {
+    cursor: pointer; }
+
+.select2-container--default .fieldhelpers-select2.select2-selection--single.select2-selection, .select2-container--default .fieldhelpers-select2.select2-selection--multiple.select2-selection {
+  border-radius: 0;
+  border: 1px solid #ddd;
+  -webkit-box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.07);
+          box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.07);
+  outline: none;
+  margin: 1px;
+  height: auto; }
+
+.select2-container--default .fieldhelpers-select2.select2-selection--single .select2-selection__rendered, .select2-container--default .fieldhelpers-select2.select2-selection--multiple .select2-selection__rendered {
+  line-height: inherit;
+  padding: 3px 5px;
+  font-size: 14px; }
+
+.select2-container--default .fieldhelpers-select2.select2-selection--single .select2-search, .select2-container--default .fieldhelpers-select2.select2-selection--multiple .select2-search {
+  margin-bottom: 0; }
+
+.select2-container--default .fieldhelpers-select2.select2-selection--single .select2-selection__choice, .select2-container--default .fieldhelpers-select2.select2-selection--multiple .select2-selection__choice {
+  border-radius: 0; }
+
+.select2-container--default .fieldhelpers-select2.select2-selection--single .select2-selection__clear, .select2-container--default .fieldhelpers-select2.select2-selection--multiple .select2-selection__clear {
+  margin-right: 15px; }
+
+.select2-container--default .fieldhelpers-select2.select2-dropdown {
+  border-radius: 0;
+  border: 1px solid #ddd;
+  -webkit-box-shadow: 5px 5px 40px rgba(0, 0, 0, 0.3);
+          box-shadow: 5px 5px 40px rgba(0, 0, 0, 0.3); }
+  .select2-container--default .fieldhelpers-select2.select2-dropdown .select2-results__option--highlighted[aria-selected] {
+    background-color: #007AB1; }
+  .select2-container--default .fieldhelpers-select2.select2-dropdown .select2-results__option {
+    margin-bottom: 0; }
+
+.fieldhelpers-field-table .fieldhelpers-field-table-loading {
+  text-align: center; }
+  .fieldhelpers-field-table .fieldhelpers-field-table-loading .spinner {
+    float: none;
+    display: inline-block; }
+
+.fieldhelpers-field-table table {
+  width: 100%;
+  border-collapse: collapse; }
+
+.fieldhelpers-field-table th, .fieldhelpers-field-table td {
+  padding: 5px; }
+
+.fieldhelpers-field-table thead input[type="text"] {
+  background: #fff78a; }
+
+.fieldhelpers-field-table input[type="text"] {
+  width: 100%; }
+
+.fieldhelpers-field-table .fieldhelpers-field-table-delete-columns {
+  text-align: center; }
+
+.fieldhelpers-field-toggle-container {
+  position: relative;
+  display: inline-block;
+  width: 60px;
+  height: 34px; }
+  .fieldhelpers-field-toggle-container.checked .fieldhelpers-field-toggle-slider {
+    background-color: #007AB1; }
+    .fieldhelpers-field-toggle-container.checked .fieldhelpers-field-toggle-slider:before {
+      -webkit-transform: translateX(26px);
+          -ms-transform: translateX(26px);
+              transform: translateX(26px); }
+  .fieldhelpers-field-toggle-container .fieldhelpers-field-toggle-slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #ccc;
+    -webkit-transition: -webkit-transform 300ms;
+    transition: -webkit-transform 300ms;
+    transition: transform 300ms;
+    transition: transform 300ms, -webkit-transform 300ms; }
+    .fieldhelpers-field-toggle-container .fieldhelpers-field-toggle-slider:before {
+      position: absolute;
+      content: "";
+      height: 26px;
+      width: 26px;
+      left: 4px;
+      bottom: 4px;
+      background-color: white;
+      -webkit-transition: -webkit-transform 300ms;
+      transition: -webkit-transform 300ms;
+      transition: transform 300ms;
+      transition: transform 300ms, -webkit-transform 300ms; }
+
+.fieldhelpers-field-wysiwyg-label {
+  font-weight: bold; }
+
+.fieldhelpers-field-tip {
+  position: relative;
+  display: inline-block; }
+  .fieldhelpers-field-tip.fieldhelpers-field-tip-align-left .fieldhelpers-field-tip-text {
+    left: -10px; }
+    .fieldhelpers-field-tip.fieldhelpers-field-tip-align-left .fieldhelpers-field-tip-text:before {
+      left: 10px; }
+  .fieldhelpers-field-tip.fieldhelpers-field-tip-align-right .fieldhelpers-field-tip-text {
+    right: -10px; }
+    .fieldhelpers-field-tip.fieldhelpers-field-tip-align-right .fieldhelpers-field-tip-text:before {
+      right: 10px; }
+  .fieldhelpers-field-tip:hover .fieldhelpers-field-tip-text {
+    visibility: visible;
+    opacity: 1;
+    -webkit-transform: translateY(0);
+        -ms-transform: translateY(0);
+            transform: translateY(0); }
+  .fieldhelpers-field-tip:hover .fieldhelpers-field-tip-toggle {
+    color: #007AB1; }
+  .fieldhelpers-field-tip .fieldhelpers-field-tip-toggle {
+    cursor: pointer;
+    -webkit-transition: color 300ms;
+    transition: color 300ms; }
+  .fieldhelpers-field-tip .fieldhelpers-field-tip-text {
+    position: absolute;
+    visibility: hidden;
+    opacity: 0;
+    top: 100%;
+    margin-top: 15px;
+    background: #007AB1;
+    color: #fff;
+    padding: 1em;
+    width: 300px;
+    text-align: left;
+    -webkit-box-shadow: 5px 5px 40px rgba(0, 0, 0, 0.3);
+            box-shadow: 5px 5px 40px rgba(0, 0, 0, 0.3);
+    -webkit-transform: translateY(10px);
+        -ms-transform: translateY(10px);
+            transform: translateY(10px);
+    -webkit-transition: visibility 300ms, opacity 300ms, -webkit-transform 300ms;
+    transition: visibility 300ms, opacity 300ms, -webkit-transform 300ms;
+    transition: visibility 300ms, opacity 300ms, transform 300ms;
+    transition: visibility 300ms, opacity 300ms, transform 300ms, -webkit-transform 300ms;
+    z-index: 100; }
+    .fieldhelpers-field-tip .fieldhelpers-field-tip-text:before {
+      content: '';
+      position: absolute;
+      bottom: 100%;
+      width: 0;
+      height: 0;
+      border-style: solid;
+      border-width: 0 10px 10px 10px;
+      border-color: transparent transparent #007AB1 transparent; }
+    .fieldhelpers-field-tip .fieldhelpers-field-tip-text:after {
+      content: '';
+      position: absolute;
+      bottom: 100%;
+      left: 0;
+      width: 100%;
+      height: 15px; }
+    .fieldhelpers-field-tip .fieldhelpers-field-tip-text a {
+      color: inherit !important;
+      text-decoration: underline; }
+
+/*# sourceMappingURL=data:application/json;charset=utf8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImdsb2JhbC9fY29tbW9uLnNjc3MiLCJnbG9iYWwvX2xheW91dC5zY3NzIiwiZmllbGRzL19maWVsZC5zY3NzIiwiZmllbGRzL19maWVsZC1jaGVja2JveC5zY3NzIiwiZ2xvYmFsL19zZXR0aW5ncy5zY3NzIiwiZmllbGRzL19maWVsZC1jb2xvcnBpY2tlci5zY3NzIiwiZmllbGRzL19maWVsZC1kYXRlcGlja2VyLnNjc3MiLCJmaWVsZHMvX2ZpZWxkLWRhdGV0aW1lcGlja2VyLnNjc3MiLCJmaWVsZHMvX2ZpZWxkLWhpZGRlbi5zY3NzIiwiZmllbGRzL19maWVsZC1saXN0LnNjc3MiLCJmaWVsZHMvX2ZpZWxkLW1lZGlhLnNjc3MiLCJmaWVsZHMvX2ZpZWxkLW51bWJlci5zY3NzIiwiZmllbGRzL19maWVsZC1yYWRpby5zY3NzIiwiZmllbGRzL19maWVsZC1yZXBlYXRlci5zY3NzIiwiZmllbGRzL19maWVsZC1zZWxlY3Quc2NzcyIsImZpZWxkcy9fZmllbGQtdGFibGUuc2NzcyIsImZpZWxkcy9fZmllbGQtdG9nZ2xlLnNjc3MiLCJmaWVsZHMvX2ZpZWxkLXd5c2l3eWcuc2NzcyIsImNvbXBvbmVudHMvX2ZpZWxkLXRpcC5zY3NzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBO0VBQ0UsdUJBQXNCO0VBQ3RCLGVBQWMsRUFDZjs7QUNHRDtFQUxFLCtCQUFzQjtVQUF0Qix1QkFBc0I7RUFDdEIsZUFBYztFQUNkLFlBQVcsRUFLWjs7QUFJQztFQVhBLCtCQUFzQjtVQUF0Qix1QkFBc0I7RUFDdEIsZUFBYztFQUNkLFlBQVc7RUFZVCxZQUFPLEVBS1I7RUFIQztJQUxGO01BTUksWUFBVyxFQUVkLEVBQUE7O0FBUkQ7RUFYQSwrQkFBc0I7VUFBdEIsdUJBQXNCO0VBQ3RCLGVBQWM7RUFDZCxZQUFXO0VBWVQsV0FBTyxFQUtSO0VBSEM7SUFMRjtNQU1JLFlBQVcsRUFFZCxFQUFBOztBQVJEO0VBWEEsK0JBQXNCO1VBQXRCLHVCQUFzQjtFQUN0QixlQUFjO0VBQ2QsWUFBVztFQVlULGlCQUFPLEVBS1I7RUFIQztJQUxGO01BTUksWUFBVyxFQUVkLEVBQUE7O0FBUkQ7RUFYQSwrQkFBc0I7VUFBdEIsdUJBQXNCO0VBQ3RCLGVBQWM7RUFDZCxZQUFXO0VBWVQsV0FBTyxFQUtSO0VBSEM7SUFMRjtNQU1JLFlBQVcsRUFFZCxFQUFBOztBQVJEO0VBWEEsK0JBQXNCO1VBQXRCLHVCQUFzQjtFQUN0QixlQUFjO0VBQ2QsWUFBVztFQVlULFdBQU8sRUFLUjtFQUhDO0lBTEY7TUFNSSxZQUFXLEVBRWQsRUFBQTs7QUNwQkg7RUFDRSxtQkFBa0IsRUFDbkI7O0FBRUQ7RUFDRSxxQkFBb0IsRUFDckI7O0FDTkQ7RUFDRSxzQkFBcUI7RUFDckIsMEJBQXlCO0VBQ3pCLGlCQUFnQjtFQUNoQixhQUFZO0VBQ1osZ0JBQWUsRUFDaEI7O0FBRUQ7RUFDRSxtQkFBa0I7RUFDbEIsZ0JBQWU7RUFDZixxQ0FBNEI7RUFBNUIsNkJBQTRCO0VBQzVCLGtCQUFpQixFQW1EbEI7RUF2REQ7SUFPSSxvQkFBNEI7SUFDNUIsa0NBQXlCO0lBQXpCLDBCQUF5QixFQUMxQjtFQVRIO0lBWUksWUFBVztJQUNYLFlBQVc7SUFDWCxlQUFjLEVBQ2Y7RUFmSDtJQWtCSSxpQ0FBZ0MsRUFDakM7RUFuQkg7SUFzQk0sb0JDOUJpQixFRHVDcEI7SUEvQkg7TUF5QlEsb0JBQXNDLEVBQ3pDO0lBMUJMO01BNkJNLFlBQVcsRUFDWjtFQTlCTDtJQWtDSSxXQUFVO0lBQ1YsWUFBVztJQUNYLCtCQUFzQjtZQUF0Qix1QkFBc0I7SUFDdEIsa0JBQWlCO0lBQ2pCLG1CQUFrQixFQUNuQjtFQXZDSDtJQTBDSSxnQkFBZSxFQUNoQjtFQTNDSDtJQThDSSxlQUFjO0lBQ2QsWUFBVztJQUNYLFdBQVU7SUFDVixrQkFBaUI7SUFDakIsaUJBQWdCO0lBQ2hCLCtCQUE4QjtJQUM5QixrQkFBaUI7SUFDakIsK0JBQXNCO1lBQXRCLHVCQUFzQixFQUN2Qjs7QUU5REg7RUFDRSxtQkFBa0IsRUFTbkI7RUFWRDtJQUlJLG1CQUFrQjtJQUNsQixRQUFPO0lBQ1AsVUFBUztJQUNULG9EQUFrQztZQUFsQyw0Q0FBa0M7SUFDbEMsYUFBWSxFQUNiOztBQ1RILGdDQUFnQztBQUNoQztFQUNFLFdBQVU7RUFDVixVQUFTO0VBR1QsaUJBQWdCO0VBQ2hCLHVCQUFzQjtFQUN0QiwwQkFBeUI7RUFDekIsaUJBQWdCO0VBQ2hCLG1EQUFrRDtFQUNsRCwyQ0FBMEM7RUFDMUMsZ0JBQWU7RUFDZixZQUFXLEVBQ1o7O0FBRUQ7RUFDRSxXQUFVO0VBQ1YscUNBQW9DO0VBR3BDLGlCQUFnQixFQUNqQjs7QUFFRDtFQUNFLGdCQUFlO0VBQ2YsVUFBUztFQUNULGFBQVk7RUFDWiwwQkFBeUIsRUFDMUI7O0FBRUQ7O0VBRUUsdUJBQXNCO0VBQ3RCLGFBQVk7RUFDWixZQUFXO0VBQ1gsb0JBQW1CLEVBQ3BCOztBQUVEO0VBQ0Usd0JBQXVCO0VBQ3ZCLDBCQUF5QjtFQUN6QixnQkFBZSxFQUNoQjs7QUFFRDtFQUNFLFVBQVM7RUFDVCxnQkFBZTtFQUNmLFlBQVc7RUFDWCxnQkFBZTtFQUNmLGtCQUFpQjtFQUNqQixtQkFBa0IsRUFDbkI7O0FBRUQ7O0VBRUUsbUJBQWtCO0VBQ2xCLE9BQU07RUFDTixhQUFZO0VBQ1osWUFBVyxFQUNaOztBQUVEOztFQUVFLGFBQVksRUFDYjs7QUFFRDs7RUFFRSxRQUFPLEVBQ1I7O0FBRUQ7O0VBRUUsU0FBUSxFQUNUOztBQUVEOztFQUVFLGNBQWEsRUFDZDs7QUFFRDtFQUNFLFlBQVcsRUFDWjs7QUFFRDtFQUNFLGFBQVksRUFDYjs7QUFFRDs7RUFFRSxtQ0FBa0M7RUFDbEMsa0JBQWlCO0VBQ2pCLFlBQVc7RUFDWCxZQUFXO0VBQ1gsb0NBQW1DO0VBQ25DLG1DQUFrQztFQUNsQyxZQUFXO0VBQ1gsYUFBWSxFQUNiOztBQUVEO0VBQ0UsaUJBQWdCLEVBQ2pCOztBQUVEO0VBQ0UsaUJBQWdCLEVBQ2pCOztBQUVEOztFQUVFLGFBQVksRUFDYjs7QUFFRDs7RUFFRSxXQUFVLEVBQ1g7O0FBRUQ7RUFDRSxZQUFXO0VBQ1gsaUJBQWdCLEVBQ2pCOztBQUVEO0VBQ0UsY0FBYSxFQUNkOztBQUVEO0VBQ0UsV0FBVTtFQUNWLDBCQUF5QixFQUMxQjs7QUFFRDtFQUNFLG9CQUFtQixFQUNwQjs7QUFFRDtFQUNFLHdCQUF1QjtFQUN2QixhQUFZO0VBQ1osbUJBQWtCO0VBQ2xCLHNCQUFxQjtFQUNyQixZQUFXO0VBQ1gsZUFBYztFQUNkLGtCQUFpQjtFQUNqQixvQkFBbUI7RUFDbkIsWUFBVyxFQUNaOztBQUVEO0VBQ0UsYUFBWSxFQUNiOztBQUdEO0VBRUksb0JBQW1CLEVBQ3BCOztBQUhIO0VBTUksb0JBQW1CLEVBQ3BCOztBQVBIO0VBV00sMEJBQXlCO0VBQ3pCLDBCQUF5QixFQUMxQjs7QUFiTDtFQWdCTSwwQkFBeUIsRUFDMUI7O0FBakJMO0VBb0JNLG9CQUFtQjtFQUNuQixZQUFXLEVBQ1o7O0FBdEJMO0VBeUJNLGVBQWMsRUFDZjs7QUExQkw7RUE2Qk0sb0JBQW1CO0VBQ25CLFlBQVcsRUFDWjs7QUMxTEw7RUFFQyxhQUFZLEVBZ0NaO0VBbENEO0lBU0UsWUFBVztJQUNYLHNCQUFxQjtJQUNyQixvQkFBbUI7SUFDbkIsb0NBQTJCO1lBQTNCLDRCQUEyQjtJQUMzQixvQkFBbUI7SUFDbkIsc0JBQXFCO0lBQ3JCLHNCQUFxQjtJQUNyQixnQkFBZTtJQUNmLGtCQUFpQjtJQUNqQixhQUFZO0lBQ1osVUFBUztJQUNULG9CQUFtQjtJQUNuQixnQkFBZTtJQUNmLGtCQUFpQjtJQUNqQixvQkFBbUI7SUFDbkIseUJBQXdCO0lBQ3hCLG1CQUFrQjtJQUNsQixvQkFBbUI7SUFDbkIsK0JBQXNCO1lBQXRCLHVCQUFzQjtJQUd0QixrQkFBaUIsRUFFakI7O0FDaENGO0VBQ0UsY0FBYSxFQUNkOztBQ0ZEO0VBRUksdUJBQXNCO0VBQ3RCLHVCQUFzQjtFQUN0QixlQUFjO0VBQ2QscUJBQW9CO0VBQ3BCLGFBQVksRUFDYjs7QUFQSDtFQVVJLFlBQVcsRUFDWjs7QUNYSDtFQUVJLGVBQWM7RUFDZCxZQUFXO0VBQ1gsc0JBQXFCO0VBQ3JCLCtCQUFzQjtVQUF0Qix1QkFBc0IsRUFDdkI7O0FBTkg7RUFTSSxnQkFBZSxFQUNoQjs7QUNWSDtFQUVJLGFBQVksRUFjYjtFQWhCSDtJQUtNLG1CQUFrQixFQVVuQjtJQWZMO01BUVEsNEJBQTJCO01BQzNCLG1CQUFrQjtNQUNsQiwwQkFBeUI7TUFDekIsU0FBUTtNQUNSLFlBQVc7TUFDWCxvQ0FBMkI7VUFBM0IsZ0NBQTJCO2NBQTNCLDRCQUEyQixFQUM1Qjs7QUFkUDtFQW9CSSxhQUFZO0VBQ1osa0JBQWlCO0VBQ2pCLFlBQVc7RUFDWCxXQUFVO0VBQ1YsVUFBUztFQUNULFlBQVc7RUFDWCxtQkFBa0IsRUFDbkI7O0FBM0JIO0VBOEJJLGVBQWM7RUFDZCxhQUFZO0VBQ1osWUFBVztFQUNYLGtCQUFpQjtFQUNqQixXQUFVO0VBQ1YsZ0JBQWU7RUFDZixZQUFXO0VBQ1gsb0JQckNtQjtFT3NDbkIsMEJBQTRDO0VBQzVDLG9DQUE4QztVQUE5Qyw0QkFBOEM7RUFDOUMsY0FBYTtFQUNiLGlCQUFnQjtFQUNoQixnQkFBZSxFQW1CaEI7RUE3REg7SUE2Q00sWUFBVztJQUNYLG9CQUF1QztJQUN2QyxzQlAvQ2lCO0lPZ0RqQixvQ1BoRGlCO1lPZ0RqQiw0QlBoRGlCLEVPaURsQjtFQWpETDtJQW9ETSxtQ0FBMEI7UUFBMUIsK0JBQTBCO1lBQTFCLDJCQUEwQixFQUMzQjtFQXJETDtJQXdETSxtQkFBa0I7SUFDbEIscUJBQW9CO0lBQ3BCLFlBQVc7SUFDWCxhQUFZLEVBQ2I7O0FBNURMO0VBZ0VJLDRCQUEyQjtFQUMzQiw2QkFBNEI7RUFDNUIsdUJBQXNCLEVBQ3ZCOztBQW5FSDtFQXNFSSwrQkFBOEI7RUFDOUIsZ0NBQStCLEVBQ2hDOztBQ3hFSDtFQUNFLHNCQUFxQjtFQUNyQiwwQkFBeUI7RUFDekIsaUJBQWdCO0VBQ2hCLGFBQVk7RUFDWixnQkFBZSxFQUNoQjs7QUFFRDtFQUNFLG1CQUFrQjtFQUNsQixnQkFBZTtFQUNmLHFDQUE0QjtFQUE1Qiw2QkFBNEI7RUFDNUIsYUFBWSxFQW9EYjtFQXhERDtJQU9JLG9CQUE0QjtJQUM1QixrQ0FBeUI7SUFBekIsMEJBQXlCLEVBQzFCO0VBVEg7SUFZSSxZQUFXO0lBQ1gsWUFBVztJQUNYLGVBQWMsRUFDZjtFQWZIO0lBa0JJLGlDQUFnQyxFQUNqQztFQW5CSDtJQXNCSSxvQlI5Qm1CLEVRdUNwQjtJQS9CSDtNQXlCTSxvQkFBc0MsRUFDdkM7SUExQkw7TUE2Qk0sWUFBVyxFQUNaO0VBOUJMO0lBa0NJLFdBQVU7SUFDVixZQUFXO0lBQ1gsK0JBQXNCO1lBQXRCLHVCQUFzQjtJQUN0QixrQkFBaUI7SUFDakIsbUJBQWtCLEVBQ25CO0VBdkNIO0lBMENJLGdCQUFlLEVBQ2hCO0VBM0NIO0lBOENJLGVBQWM7SUFDZCxZQUFXO0lBQ1gsV0FBVTtJQUNWLGtCQUFpQjtJQUNqQixpQkFBZ0I7SUFDaEIsK0JBQThCO0lBQzlCLGFBQVk7SUFDWixrQkFBaUI7SUFDakIsK0JBQXNCO1lBQXRCLHVCQUFzQixFQUN2Qjs7QUMvREg7RUFDRSxrQkFBaUIsRUFDbEI7O0FBRUQ7RUFFSSx3QkFBdUIsRUFDeEI7O0FBR0g7RUFDRSxlQUFjO0VBQ2QsZ0JBQWU7RUFDZix1QkFBc0I7RUFDdEIsaUJBQWdCLEVBc0JqQjtFQTFCRDtJQU9JLFlBQVc7SUFDWCxlQUFjO0lBQ2QsWUFBVyxFQUNaO0VBVkg7SUFhSSxhQUFZLEVBQ2I7RUFkSDtJQWlCSSxhQUFZO0lBQ1osYUFBWTtJQUNaLG9CQUFtQjtJQUNuQixrSkFBK0k7SUFHL0ksMElBQXVJO0lBQ3ZJLHlCQUF3QixFQUN6Qjs7QUFHSDtFQUVJLGNBQWEsRUFDZDs7QUFISDtFQU1JLHlCQUF3QixFQUt6QjtFQVhIO0lBU00sYUFBWSxFQUNiOztBQVZMO0VBY0ksZ0JBQWUsRUFDaEI7O0FBZkg7RUFtQk0sa0NBQXlCO01BQXpCLDhCQUF5QjtVQUF6QiwwQkFBeUIsRUFDMUI7O0FBcEJMO0VBd0JJLHVEQUFzQztFQUF0QywrQ0FBc0M7RUFBdEMsdUNBQXNDO0VBQXRDLDJFQUFzQyxFQUt2QztFQTdCSDtJQTJCTSxnQkFBZSxFQUNoQjs7QUNsRUw7RUFNTSxpQkFBZ0I7RUFDaEIsdUJBQXNCO0VBQ3RCLHdEQUFxQztVQUFyQyxnREFBcUM7RUFDckMsY0FBYTtFQUNiLFlBQVc7RUFDWCxhQUFZLEVBQ2I7O0FBWkw7RUFlTSxxQkFBb0I7RUFDcEIsaUJBQWdCO0VBQ2hCLGdCQUFlLEVBQ2hCOztBQWxCTDtFQXFCTSxpQkFBZ0IsRUFDakI7O0FBdEJMO0VBeUJNLGlCQUFnQixFQUNqQjs7QUExQkw7RUE2Qk0sbUJBQWtCLEVBQ25COztBQTlCTDtFQWtDSSxpQkFBZ0I7RUFDaEIsdUJBQXNCO0VBQ3RCLG9EQUFrQztVQUFsQyw0Q0FBa0MsRUFTbkM7RUE3Q0g7SUF1Q00sMEJWdkNpQixFVXdDbEI7RUF4Q0w7SUEyQ00saUJBQWdCLEVBQ2pCOztBQzVDTDtFQUdJLG1CQUFrQixFQU1uQjtFQVRIO0lBTU0sWUFBVztJQUNYLHNCQUFxQixFQUN0Qjs7QUFSTDtFQVlJLFlBQVc7RUFDWCwwQkFBeUIsRUFDMUI7O0FBZEg7RUFpQkksYUFBWSxFQUNiOztBQWxCSDtFQXNCTSxvQkFBbUIsRUFDcEI7O0FBdkJMO0VBMkJJLFlBQVcsRUFDWjs7QUE1Qkg7RUErQkksbUJBQWtCLEVBQ25COztBQ2hDSDtFQUNFLG1CQUFrQjtFQUNsQixzQkFBcUI7RUFDckIsWUFBVztFQUNYLGFBQVksRUFpQ2I7RUFyQ0Q7SUFRTSwwQlpSaUIsRVlhbEI7SUFiTDtNQVdRLG9DQUEyQjtVQUEzQixnQ0FBMkI7Y0FBM0IsNEJBQTJCLEVBQzVCO0VBWlA7SUFpQkksbUJBQWtCO0lBQ2xCLGdCQUFlO0lBQ2YsT0FBTTtJQUNOLFFBQU87SUFDUCxTQUFRO0lBQ1IsVUFBUztJQUNULHVCQUFzQjtJQUN0Qiw0Q0FBMkI7SUFBM0Isb0NBQTJCO0lBQTNCLDRCQUEyQjtJQUEzQixxREFBMkIsRUFZNUI7SUFwQ0g7TUEyQk0sbUJBQWtCO01BQ2xCLFlBQVc7TUFDWCxhQUFZO01BQ1osWUFBVztNQUNYLFVBQVM7TUFDVCxZQUFXO01BQ1gsd0JBQXVCO01BQ3ZCLDRDQUEyQjtNQUEzQixvQ0FBMkI7TUFBM0IsNEJBQTJCO01BQTNCLHFEQUEyQixFQUM1Qjs7QUNuQ0w7RUFDRSxrQkFBaUIsRUFDbEI7O0FDRkQ7RUFDRSxtQkFBa0I7RUFDbEIsc0JBQXFCLEVBZ0Z0QjtFQWxGRDtJQU1NLFlBQVcsRUFLWjtJQVhMO01BU1EsV0FBVSxFQUNYO0VBVlA7SUFnQk0sYUFBWSxFQUtiO0lBckJMO01BbUJRLFlBQVcsRUFDWjtFQXBCUDtJQTBCTSxvQkFBbUI7SUFDbkIsV0FBVTtJQUNWLGlDQUF3QjtRQUF4Qiw2QkFBd0I7WUFBeEIseUJBQXdCLEVBQ3pCO0VBN0JMO0lBZ0NNLGVkaENpQixFY2lDbEI7RUFqQ0w7SUFxQ0ksZ0JBQWU7SUFDZixnQ0FBdUI7SUFBdkIsd0JBQXVCLEVBQ3hCO0VBdkNIO0lBMENJLG1CQUFrQjtJQUNsQixtQkFBa0I7SUFDbEIsV0FBVTtJQUNWLFVBQVM7SUFDVCxpQkFBZ0I7SUFDaEIsb0JkL0NtQjtJY2dEbkIsWUFBVztJQUNYLGFBQVk7SUFDWixhQUFZO0lBQ1osaUJBQWdCO0lBQ2hCLG9EQUFrQztZQUFsQyw0Q0FBa0M7SUFDbEMsb0NBQTJCO1FBQTNCLGdDQUEyQjtZQUEzQiw0QkFBMkI7SUFDM0IsNkVBQTREO0lBQTVELHFFQUE0RDtJQUE1RCw2REFBNEQ7SUFBNUQsc0ZBQTREO0lBQzVELGFBQVksRUEwQmI7SUFqRkg7TUEwRE0sWUFBVztNQUNYLG1CQUFrQjtNQUNsQixhQUFZO01BQ1osU0FBUTtNQUNSLFVBQVM7TUFDVCxvQkFBbUI7TUFDbkIsK0JBQThCO01BQzlCLDBEQUFnRSxFQUNqRTtJQWxFTDtNQXFFTSxZQUFXO01BQ1gsbUJBQWtCO01BQ2xCLGFBQVk7TUFDWixRQUFPO01BQ1AsWUFBVztNQUNYLGFBQVksRUFDYjtJQTNFTDtNQThFTSwwQkFBeUI7TUFDekIsMkJBQTBCLEVBQzNCIiwiZmlsZSI6ImFwcC5jc3MiLCJzb3VyY2VzQ29udGVudCI6WyIuZmllbGRoZWxwZXJzLWZpZWxkc2V0IHtcbiAgYm9yZGVyOiAxcHggc29saWQgI2RkZDtcbiAgcGFkZGluZzogMC41ZW07XG59IiwiQG1peGluIGZpZWxkaGVscGVycy1jb2woKSB7XG4gIGJveC1zaXppbmc6IGJvcmRlci1ib3g7XG4gIHBhZGRpbmc6IDAuNWVtO1xuICBmbG9hdDogbGVmdDtcbn1cblxuLmZpZWxkaGVscGVycy1jb2wge1xuICBAaW5jbHVkZSBmaWVsZGhlbHBlcnMtY29sKCk7XG59XG5cbkBmb3IgJGkgZnJvbSAxIHRocm91Z2ggNSB7XG5cbiAgLmZpZWxkaGVscGVycy1jb2wtI3skaX0ge1xuXG4gICAgQGluY2x1ZGUgZmllbGRoZWxwZXJzLWNvbCgpO1xuICAgIHdpZHRoOiAjezEwMCAvICRpfSN7XCIlXCJ9O1xuXG4gICAgQG1lZGlhIG9ubHkgc2NyZWVuIGFuZCAobWF4LXdpZHRoOiA2NDBweCkge1xuICAgICAgd2lkdGg6IDEwMCU7XG4gICAgfVxuICB9XG59IiwiLmZpZWxkaGVscGVycy1maWVsZCB7XG4gIG1hcmdpbi1ib3R0b206IDFlbTtcbn1cblxuLmZpZWxkaGVscGVycy1maWVsZC1oZWFkZXIge1xuICBtYXJnaW4tYm90dG9tOiAwLjVlbTtcbn0iLCIuZmllbGRoZWxwZXJzLWZpZWxkLWNoZWNrYm94LWNvbnRhaW5lciB7XG4gIGRpc3BsYXk6IGlubGluZS1ibG9jaztcbiAgYm9yZGVyOiAxcHggc29saWQgI0RGREZERjtcbiAgYmFja2dyb3VuZDogI2ZmZjtcbiAgd2lkdGg6IDMwMHB4O1xuICBtYXgtd2lkdGg6IDEwMCU7XG59XG5cbi5maWVsZGhlbHBlcnMtZmllbGQtY2hlY2tib3gtcm93IHtcbiAgcG9zaXRpb246IHJlbGF0aXZlO1xuICBjdXJzb3I6IHBvaW50ZXI7XG4gIHRyYW5zaXRpb246IGJhY2tncm91bmQgMTUwbXM7XG4gIGxpbmUtaGVpZ2h0OiAzMHB4O1xuXG4gICY6aG92ZXIge1xuICAgIGJhY2tncm91bmQ6IGRhcmtlbigjZmZmLCA1JSk7XG4gICAgdHJhbnNpdGlvbjogYmFja2dyb3VuZCAwcztcbiAgfVxuXG4gICY6YWZ0ZXIge1xuICAgIGNvbnRlbnQ6ICcnO1xuICAgIGNsZWFyOiBib3RoO1xuICAgIGRpc3BsYXk6IHRhYmxlO1xuICB9XG5cbiAgJjpub3QoOmxhc3Qtb2YtdHlwZSkge1xuICAgIGJvcmRlci1ib3R0b206IDFweCBzb2xpZCAjREZERkRGO1xuICB9XG5cbiAgJi5maWVsZGhlbHBlcnMtZmllbGQtY2hlY2tib3gtcm93LWFjdGl2ZSB7XG4gICAgICBiYWNrZ3JvdW5kOiAkcHJpbWFyeS1jb2xvcjtcblxuICAgICY6aG92ZXIge1xuICAgICAgICBiYWNrZ3JvdW5kOiBkYXJrZW4oJHByaW1hcnktY29sb3IsIDUlKTtcbiAgICB9XG5cbiAgICAuZmllbGRoZWxwZXJzLWZpZWxkLWNoZWNrYm94LWxhYmVsIHtcbiAgICAgIGNvbG9yOiAjZmZmO1xuICAgIH1cbiAgfVxuXG4gIC5maWVsZGhlbHBlcnMtZmllbGQtY2hlY2tib3gtaW5wdXQtY29udGFpbmVyIHtcbiAgICB3aWR0aDogMTUlO1xuICAgIGZsb2F0OiBsZWZ0O1xuICAgIGJveC1zaXppbmc6IGJvcmRlci1ib3g7XG4gICAgbGluZS1oZWlnaHQ6IDMwcHg7XG4gICAgdGV4dC1hbGlnbjogY2VudGVyO1xuICB9XG5cbiAgaW5wdXRbdHlwZT1cImNoZWNrYm94XCJdIHtcbiAgICBtYXJnaW46IDAgMC41ZW07XG4gIH1cblxuICAuZmllbGRoZWxwZXJzLWZpZWxkLWNoZWNrYm94LWxhYmVsIHtcbiAgICBkaXNwbGF5OiBibG9jaztcbiAgICBmbG9hdDogbGVmdDtcbiAgICB3aWR0aDogODUlO1xuICAgIGZvbnQtd2VpZ2h0OiBib2xkO1xuICAgIHBhZGRpbmc6IDAgMC41ZW07XG4gICAgYm9yZGVyLWxlZnQ6IDFweCBzb2xpZCAjREZERkRGO1xuICAgIGxpbmUtaGVpZ2h0OiAzMHB4O1xuICAgIGJveC1zaXppbmc6IGJvcmRlci1ib3g7XG4gIH1cbn0iLCIkcHJpbWFyeS1jb2xvcjogIzAwN0FCMTsiLCIuZmllbGRoZWxwZXJzLWZpZWxkLWNvbG9ycGlja2VyIHtcbiAgcG9zaXRpb246IHJlbGF0aXZlO1xuXG4gIC53cC1waWNrZXItaG9sZGVyIHtcbiAgICBwb3NpdGlvbjogYWJzb2x1dGU7XG4gICAgbGVmdDogMDtcbiAgICB0b3A6IDEwMCU7XG4gICAgYm94LXNoYWRvdzogNXB4IDVweCAzMHB4IHJnYmEoIzAwMCwgMC41KTtcbiAgICB6LWluZGV4OiAxMDA7XG4gIH1cbn0iLCIvKiBEYXRlIFBpY2tlciBEZWZhdWx0IFN0eWxlcyAqL1xuLnVpLWRhdGVwaWNrZXIge1xuICBwYWRkaW5nOiAwO1xuICBtYXJnaW46IDA7XG4gIC13ZWJraXQtYm9yZGVyLXJhZGl1czogMDtcbiAgLW1vei1ib3JkZXItcmFkaXVzOiAwO1xuICBib3JkZXItcmFkaXVzOiAwO1xuICBiYWNrZ3JvdW5kLWNvbG9yOiAjZmZmO1xuICBib3JkZXI6IDFweCBzb2xpZCAjZGZkZmRmO1xuICBib3JkZXItdG9wOiBub25lO1xuICAtd2Via2l0LWJveC1zaGFkb3c6IDAgM3B4IDZweCByZ2JhKDAsIDAsIDAsIDAuMDc1KTtcbiAgYm94LXNoYWRvdzogMCAzcHggNnB4IHJnYmEoMCwgMCwgMCwgMC4wNzUpO1xuICBtaW4td2lkdGg6IDE3ZW07XG4gIHdpZHRoOiBhdXRvO1xufVxuXG4udWktZGF0ZXBpY2tlciAqIHtcbiAgcGFkZGluZzogMDtcbiAgZm9udC1mYW1pbHk6IFwiT3BlbiBTYW5zXCIsIHNhbnMtc2VyaWY7XG4gIC13ZWJraXQtYm9yZGVyLXJhZGl1czogMDtcbiAgLW1vei1ib3JkZXItcmFkaXVzOiAwO1xuICBib3JkZXItcmFkaXVzOiAwO1xufVxuXG4udWktZGF0ZXBpY2tlciB0YWJsZSB7XG4gIGZvbnQtc2l6ZTogMTNweDtcbiAgbWFyZ2luOiAwO1xuICBib3JkZXI6IG5vbmU7XG4gIGJvcmRlci1jb2xsYXBzZTogY29sbGFwc2U7XG59XG5cbi51aS1kYXRlcGlja2VyIC51aS13aWRnZXQtaGVhZGVyLFxuLnVpLWRhdGVwaWNrZXIgLnVpLWRhdGVwaWNrZXItaGVhZGVyIHtcbiAgYmFja2dyb3VuZC1pbWFnZTogbm9uZTtcbiAgYm9yZGVyOiBub25lO1xuICBjb2xvcjogI2ZmZjtcbiAgZm9udC13ZWlnaHQ6IG5vcm1hbDtcbn1cblxuLnVpLWRhdGVwaWNrZXIgLnVpLWRhdGVwaWNrZXItaGVhZGVyIC51aS1zdGF0ZS1ob3ZlciB7XG4gIGJhY2tncm91bmQ6IHRyYW5zcGFyZW50O1xuICBib3JkZXItY29sb3I6IHRyYW5zcGFyZW50O1xuICBjdXJzb3I6IHBvaW50ZXI7XG59XG5cbi51aS1kYXRlcGlja2VyIC51aS1kYXRlcGlja2VyLXRpdGxlIHtcbiAgbWFyZ2luOiAwO1xuICBwYWRkaW5nOiAxMHB4IDA7XG4gIGNvbG9yOiAjZmZmO1xuICBmb250LXNpemU6IDE0cHg7XG4gIGxpbmUtaGVpZ2h0OiAxNHB4O1xuICB0ZXh0LWFsaWduOiBjZW50ZXI7XG59XG5cbi51aS1kYXRlcGlja2VyIC51aS1kYXRlcGlja2VyLXByZXYsXG4udWktZGF0ZXBpY2tlciAudWktZGF0ZXBpY2tlci1uZXh0IHtcbiAgcG9zaXRpb246IHJlbGF0aXZlO1xuICB0b3A6IDA7XG4gIGhlaWdodDogMzRweDtcbiAgd2lkdGg6IDM0cHg7XG59XG5cbi51aS1kYXRlcGlja2VyIC51aS1zdGF0ZS1ob3Zlci51aS1kYXRlcGlja2VyLXByZXYsXG4udWktZGF0ZXBpY2tlciAudWktc3RhdGUtaG92ZXIudWktZGF0ZXBpY2tlci1uZXh0IHtcbiAgYm9yZGVyOiBub25lO1xufVxuXG4udWktZGF0ZXBpY2tlciAudWktZGF0ZXBpY2tlci1wcmV2LFxuLnVpLWRhdGVwaWNrZXIgLnVpLWRhdGVwaWNrZXItcHJldi1ob3ZlciB7XG4gIGxlZnQ6IDA7XG59XG5cbi51aS1kYXRlcGlja2VyIC51aS1kYXRlcGlja2VyLW5leHQsXG4udWktZGF0ZXBpY2tlciAudWktZGF0ZXBpY2tlci1uZXh0LWhvdmVyIHtcbiAgcmlnaHQ6IDA7XG59XG5cbi51aS1kYXRlcGlja2VyIC51aS1kYXRlcGlja2VyLW5leHQgc3Bhbixcbi51aS1kYXRlcGlja2VyIC51aS1kYXRlcGlja2VyLXByZXYgc3BhbiB7XG4gIGRpc3BsYXk6IG5vbmU7XG59XG5cbi51aS1kYXRlcGlja2VyIC51aS1kYXRlcGlja2VyLXByZXYge1xuICBmbG9hdDogbGVmdDtcbn1cblxuLnVpLWRhdGVwaWNrZXIgLnVpLWRhdGVwaWNrZXItbmV4dCB7XG4gIGZsb2F0OiByaWdodDtcbn1cblxuLnVpLWRhdGVwaWNrZXIgLnVpLWRhdGVwaWNrZXItcHJldjpiZWZvcmUsXG4udWktZGF0ZXBpY2tlciAudWktZGF0ZXBpY2tlci1uZXh0OmJlZm9yZSB7XG4gIGZvbnQ6IG5vcm1hbCAyMHB4LzM0cHggJ2Rhc2hpY29ucyc7XG4gIHBhZGRpbmctbGVmdDogN3B4O1xuICBjb2xvcjogI2ZmZjtcbiAgc3BlYWs6IG5vbmU7XG4gIC13ZWJraXQtZm9udC1zbW9vdGhpbmc6IGFudGlhbGlhc2VkO1xuICAtbW96LW9zeC1mb250LXNtb290aGluZzogZ3JheXNjYWxlO1xuICB3aWR0aDogMzRweDtcbiAgaGVpZ2h0OiAzNHB4O1xufVxuXG4udWktZGF0ZXBpY2tlciAudWktZGF0ZXBpY2tlci1wcmV2OmJlZm9yZSB7XG4gIGNvbnRlbnQ6ICdcXGYzNDEnO1xufVxuXG4udWktZGF0ZXBpY2tlciAudWktZGF0ZXBpY2tlci1uZXh0OmJlZm9yZSB7XG4gIGNvbnRlbnQ6ICdcXGYzNDUnO1xufVxuXG4udWktZGF0ZXBpY2tlciAudWktZGF0ZXBpY2tlci1wcmV2LWhvdmVyOmJlZm9yZSxcbi51aS1kYXRlcGlja2VyIC51aS1kYXRlcGlja2VyLW5leHQtaG92ZXI6YmVmb3JlIHtcbiAgb3BhY2l0eTogMC43O1xufVxuXG4udWktZGF0ZXBpY2tlciBzZWxlY3QudWktZGF0ZXBpY2tlci1tb250aCxcbi51aS1kYXRlcGlja2VyIHNlbGVjdC51aS1kYXRlcGlja2VyLXllYXIge1xuICB3aWR0aDogMzMlO1xufVxuXG4udWktZGF0ZXBpY2tlciB0aGVhZCB7XG4gIGNvbG9yOiAjZmZmO1xuICBmb250LXdlaWdodDogNjAwO1xufVxuXG4udWktZGF0ZXBpY2tlciB0aCB7XG4gIHBhZGRpbmc6IDEwcHg7XG59XG5cbi51aS1kYXRlcGlja2VyIHRkIHtcbiAgcGFkZGluZzogMDtcbiAgYm9yZGVyOiAxcHggc29saWQgI2Y0ZjRmNDtcbn1cblxuLnVpLWRhdGVwaWNrZXIgdGQudWktZGF0ZXBpY2tlci1vdGhlci1tb250aCB7XG4gIGJvcmRlcjogdHJhbnNwYXJlbnQ7XG59XG5cbi51aS1kYXRlcGlja2VyIHRkIC51aS1zdGF0ZS1kZWZhdWx0IHtcbiAgYmFja2dyb3VuZDogdHJhbnNwYXJlbnQ7XG4gIGJvcmRlcjogbm9uZTtcbiAgdGV4dC1hbGlnbjogY2VudGVyO1xuICB0ZXh0LWRlY29yYXRpb246IG5vbmU7XG4gIHdpZHRoOiBhdXRvO1xuICBkaXNwbGF5OiBibG9jaztcbiAgcGFkZGluZzogNXB4IDEwcHg7XG4gIGZvbnQtd2VpZ2h0OiBub3JtYWw7XG4gIGNvbG9yOiAjNDQ0O1xufVxuXG4udWktZGF0ZXBpY2tlciB0ZC51aS1zdGF0ZS1kaXNhYmxlZCAudWktc3RhdGUtZGVmYXVsdCB7XG4gIG9wYWNpdHk6IDAuNTtcbn1cblxuLy8gRGVmYXVsdCBDb2xvciBTY2hlbWVcbi51aS1kYXRlcGlja2VyIHtcbiAgLnVpLXdpZGdldC1oZWFkZXIsIC51aS1kYXRlcGlja2VyLWhlYWRlciB7XG4gICAgYmFja2dyb3VuZDogIzUyYWNjYztcbiAgfVxuXG4gIHRoZWFkIHtcbiAgICBiYWNrZ3JvdW5kOiAjMDk2NDg0O1xuICB9XG5cbiAgdGQge1xuICAgICYudWktZGF0ZXBpY2tlci13ZWVrLWVuZCB7XG4gICAgICBiYWNrZ3JvdW5kLWNvbG9yOiAjZjRmNGY0O1xuICAgICAgYm9yZGVyOiAxcHggc29saWQgI2Y0ZjRmNDtcbiAgICB9XG5cbiAgICAmLnVpLWRhdGVwaWNrZXItdG9kYXkge1xuICAgICAgYmFja2dyb3VuZC1jb2xvcjogIzQ3OTZiMztcbiAgICB9XG5cbiAgICAmLnVpLWRhdGVwaWNrZXItY3VycmVudC1kYXkge1xuICAgICAgYmFja2dyb3VuZDogIzQ3OTZiMztcbiAgICAgIGNvbG9yOiAjZmZmO1xuICAgIH1cblxuICAgIGEudWktc3RhdGUtZGVmYXVsdCB7XG4gICAgICBjb2xvcjogaW5oZXJpdDtcbiAgICB9XG5cbiAgICBhLnVpLXN0YXRlLWhvdmVyIHtcbiAgICAgIGJhY2tncm91bmQ6ICMwOTY0ODQ7XG4gICAgICBjb2xvcjogI2ZmZjtcbiAgICB9XG4gIH1cbn0iLCIudWktZGF0ZXBpY2tlci1idXR0b25wYW5lIHtcblx0XG5cdHBhZGRpbmc6IDZweDtcblxuXHQudWktZGF0ZXBpY2tlci1jdXJyZW50LCAudWktZGF0ZXBpY2tlci1jbG9zZSB7XG5cblx0XHQvLyBDb3BpZWQgZnJvbSAud3AtY29yZS11aSAuYnV0dG9uXG5cdFx0Ly8galF1ZXJ5IFVJIGlzIHN1cHBvc2VkIHRvIHByb3ZpZGUgYSBgY2xhc3Nlc2Agb3B0aW9uIHRvIGFkZCBDbGFzcyBOYW1lcyB0byBlbGVtZW50cywgYnV0IGl0IGRvZXNuJ3QgYXBwZWFyIHRvIHdvcmsgd2l0aCBEYXRlcGlja2VyIG9yIERhdGV0aW1lcGlja2VyIG9yIFRpbWVwaWNrZXJcblx0XHQvLyBEb2N1bWVudGF0aW9uIHJlZmVyZW5jaW5nIGl0OiBodHRwOi8vYXBpLmpxdWVyeXVpLmNvbS9kYXRlcGlja2VyLyN0aGVtaW5nXG5cdFx0Y29sb3I6ICM1NTU7XG5cdFx0Ym9yZGVyLWNvbG9yOiAjY2NjY2NjO1xuXHRcdGJhY2tncm91bmQ6ICNmN2Y3Zjc7XG5cdFx0Ym94LXNoYWRvdzogMCAxcHggMCAjY2NjY2NjO1xuXHRcdHZlcnRpY2FsLWFsaWduOiB0b3A7XG5cdFx0ZGlzcGxheTogaW5saW5lLWJsb2NrO1xuXHRcdHRleHQtZGVjb3JhdGlvbjogbm9uZTtcblx0XHRmb250LXNpemU6IDEzcHg7XG5cdFx0bGluZS1oZWlnaHQ6IDI2cHg7XG5cdFx0aGVpZ2h0OiAyOHB4O1xuXHRcdG1hcmdpbjogMDtcblx0XHRwYWRkaW5nOiAwIDEwcHggMXB4O1xuXHRcdGN1cnNvcjogcG9pbnRlcjtcblx0XHRib3JkZXItd2lkdGg6IDFweDtcblx0XHRib3JkZXItc3R5bGU6IHNvbGlkO1xuXHRcdC13ZWJraXQtYXBwZWFyYW5jZTogbm9uZTtcblx0XHRib3JkZXItcmFkaXVzOiAzcHg7XG5cdFx0d2hpdGUtc3BhY2U6IG5vd3JhcDtcblx0XHRib3gtc2l6aW5nOiBib3JkZXItYm94O1xuXHRcdFxuXHRcdC8vIEFkZGl0aW9uYWxcblx0XHRtYXJnaW4tcmlnaHQ6IDZweDtcblxuXHR9XG5cbn0iLCIuZmllbGRoZWxwZXJzLWZpZWxkLWhpZGRlbiB7XG4gIGRpc3BsYXk6IG5vbmU7XG59IiwiLmZpZWxkaGVscGVycy1maWVsZC1saXN0IHtcbiAgLmZpZWxkaGVscGVycy1maWVsZC1saXN0LWl0ZW0ge1xuICAgIGJvcmRlcjogMXB4IHNvbGlkICNkZGQ7XG4gICAgYmFja2dyb3VuZC1jb2xvcjogI2ZmZjtcbiAgICBwYWRkaW5nOiAwLjVlbTtcbiAgICBtYXJnaW4tYm90dG9tOiAwLjVlbTtcbiAgICBjdXJzb3I6IG1vdmU7XG4gIH1cblxuICAuZmllbGRoZWxwZXJzLWZpZWxkLWxpc3QtaXRlbS1oYW5kbGUge1xuICAgIGNvbG9yOiAjYmJiO1xuICB9XG59IiwiLmZpZWxkaGVscGVycy1tZWRpYS11cGxvYWRlciB7XG4gIC5tZWRpYS11cmwge1xuICAgIGRpc3BsYXk6IGJsb2NrO1xuICAgIHdpZHRoOiAxMDAlO1xuICAgIHdvcmQtYnJlYWs6IGJyZWFrLWFsbDtcbiAgICBib3gtc2l6aW5nOiBib3JkZXItYm94O1xuICB9XG5cbiAgLmltYWdlLXByZXZpZXcge1xuICAgIG1heC13aWR0aDogMTAwJTtcbiAgfVxufSIsIi5maWVsZGhlbHBlcnMtZmllbGQtbnVtYmVyIHtcbiAgLmZpZWxkaGVscGVycy1maWVsZC1udW1iZXItY29udGFpbmVyIHtcbiAgICB3aWR0aDogMTAwcHg7XG5cbiAgICAmW2RhdGEtcG9zdGZpeF0ge1xuICAgICAgcG9zaXRpb246IHJlbGF0aXZlO1xuXG4gICAgICAmOmFmdGVyIHtcbiAgICAgICAgY29udGVudDogYXR0cihkYXRhLXBvc3RmaXgpO1xuICAgICAgICBwb3NpdGlvbjogYWJzb2x1dGU7XG4gICAgICAgIHJpZ2h0OiBjYWxjKDIwcHggKyAwLjVlbSk7XG4gICAgICAgIHRvcDogNTAlO1xuICAgICAgICBjb2xvcjogI2FhYTtcbiAgICAgICAgdHJhbnNmb3JtOiB0cmFuc2xhdGVZKC01MCUpO1xuICAgICAgfVxuICAgIH1cbiAgfVxuXG4gIC8vIEV4Y2Vzc2l2ZSBzZWxlY3RvciBiZWNhdXNlIFdQIHRyaWVzIHRvIGNoYW5nZSBpdCBmb3IgbW9iaWxlXG4gIGlucHV0W3R5cGU9XCJ0ZXh0XCJdLmZpZWxkaGVscGVycy1maWVsZC1pbnB1dCB7XG4gICAgaGVpZ2h0OiA0MHB4O1xuICAgIGxpbmUtaGVpZ2h0OiA0MHB4O1xuICAgIHdpZHRoOiA4MHB4O1xuICAgIHBhZGRpbmc6IDA7XG4gICAgbWFyZ2luOiAwO1xuICAgIGZsb2F0OiBsZWZ0O1xuICAgIHRleHQtYWxpZ246IGNlbnRlcjtcbiAgfVxuXG4gIC5maWVsZGhlbHBlcnMtZmllbGQtbnVtYmVyLWluY3JlYXNlLCAuZmllbGRoZWxwZXJzLWZpZWxkLW51bWJlci1kZWNyZWFzZSB7XG4gICAgZGlzcGxheTogYmxvY2s7XG4gICAgaGVpZ2h0OiAyMHB4O1xuICAgIHdpZHRoOiAyMHB4O1xuICAgIGxpbmUtaGVpZ2h0OiAyMHB4O1xuICAgIHBhZGRpbmc6IDA7XG4gICAgZm9udC1zaXplOiAxNHB4O1xuICAgIGNvbG9yOiAjZmZmO1xuICAgIGJhY2tncm91bmQ6ICRwcmltYXJ5LWNvbG9yO1xuICAgIGJvcmRlcjogMXB4IHNvbGlkIGRhcmtlbigkcHJpbWFyeS1jb2xvciwgNSUpO1xuICAgIGJveC1zaGFkb3c6IDAgMXB4IDAgZGFya2VuKCRwcmltYXJ5LWNvbG9yLCA1JSk7XG4gICAgb3V0bGluZTogbm9uZTtcbiAgICBib3JkZXItcmFkaXVzOiAwO1xuICAgIGN1cnNvcjogcG9pbnRlcjtcblxuICAgICY6aG92ZXIge1xuICAgICAgY29sb3I6ICNmZmY7XG4gICAgICBiYWNrZ3JvdW5kOiBsaWdodGVuKCRwcmltYXJ5LWNvbG9yLCA1JSk7XG4gICAgICBib3JkZXItY29sb3I6ICRwcmltYXJ5LWNvbG9yO1xuICAgICAgYm94LXNoYWRvdzogMCAxcHggMCAkcHJpbWFyeS1jb2xvcjtcbiAgICB9XG5cbiAgICAmOmFjdGl2ZSB7XG4gICAgICB0cmFuc2Zvcm06IHRyYW5zbGF0ZVkoMXB4KTtcbiAgICB9XG5cbiAgICAuZGFzaGljb25zIHtcbiAgICAgIGZvbnQtc2l6ZTogaW5oZXJpdDtcbiAgICAgIGxpbmUtaGVpZ2h0OiBpbmhlcml0O1xuICAgICAgd2lkdGg6IGF1dG87XG4gICAgICBoZWlnaHQ6IGF1dG87XG4gICAgfVxuICB9XG5cbiAgLmZpZWxkaGVscGVycy1maWVsZC1udW1iZXItaW5jcmVhc2Uge1xuICAgIGJvcmRlci10b3AtbGVmdC1yYWRpdXM6IDNweDtcbiAgICBib3JkZXItdG9wLXJpZ2h0LXJhZGl1czogM3B4O1xuICAgIGJvcmRlci1ib3R0b20td2lkdGg6IDA7XG4gIH1cblxuICAuZmllbGRoZWxwZXJzLWZpZWxkLW51bWJlci1kZWNyZWFzZSB7XG4gICAgYm9yZGVyLWJvdHRvbS1sZWZ0LXJhZGl1czogM3B4O1xuICAgIGJvcmRlci1ib3R0b20tcmlnaHQtcmFkaXVzOiAzcHg7XG4gIH1cbn0iLCIuZmllbGRoZWxwZXJzLWZpZWxkLXJhZGlvLWNvbnRhaW5lciB7XG4gIGRpc3BsYXk6IGlubGluZS1ibG9jaztcbiAgYm9yZGVyOiAxcHggc29saWQgI0RGREZERjtcbiAgYmFja2dyb3VuZDogI2ZmZjtcbiAgd2lkdGg6IDMwMHB4O1xuICBtYXgtd2lkdGg6IDEwMCU7XG59XG5cbi5maWVsZGhlbHBlcnMtZmllbGQtcmFkaW8tcm93IHtcbiAgcG9zaXRpb246IHJlbGF0aXZlO1xuICBjdXJzb3I6IHBvaW50ZXI7XG4gIHRyYW5zaXRpb246IGJhY2tncm91bmQgMTUwbXM7XG4gIGhlaWdodDogMzBweDtcblxuICAmOmhvdmVyIHtcbiAgICBiYWNrZ3JvdW5kOiBkYXJrZW4oI2ZmZiwgNSUpO1xuICAgIHRyYW5zaXRpb246IGJhY2tncm91bmQgMHM7XG4gIH1cblxuICAmOmFmdGVyIHtcbiAgICBjb250ZW50OiAnJztcbiAgICBjbGVhcjogYm90aDtcbiAgICBkaXNwbGF5OiB0YWJsZTtcbiAgfVxuXG4gICY6bm90KDpsYXN0LW9mLXR5cGUpIHtcbiAgICBib3JkZXItYm90dG9tOiAxcHggc29saWQgI0RGREZERjtcbiAgfVxuXG4gICYuZmllbGRoZWxwZXJzLWZpZWxkLXJhZGlvLXJvdy1hY3RpdmUge1xuICAgIGJhY2tncm91bmQ6ICRwcmltYXJ5LWNvbG9yO1xuXG4gICAgJjpob3ZlciB7XG4gICAgICBiYWNrZ3JvdW5kOiBkYXJrZW4oJHByaW1hcnktY29sb3IsIDUlKTtcbiAgICB9XG5cbiAgICAuZmllbGRoZWxwZXJzLWZpZWxkLXJhZGlvLWxhYmVsIHtcbiAgICAgIGNvbG9yOiAjZmZmO1xuICAgIH1cbiAgfVxuXG4gIC5maWVsZGhlbHBlcnMtZmllbGQtcmFkaW8taW5wdXQtY29udGFpbmVyIHtcbiAgICB3aWR0aDogMTUlO1xuICAgIGZsb2F0OiBsZWZ0O1xuICAgIGJveC1zaXppbmc6IGJvcmRlci1ib3g7XG4gICAgbGluZS1oZWlnaHQ6IDMwcHg7XG4gICAgdGV4dC1hbGlnbjogY2VudGVyO1xuICB9XG5cbiAgaW5wdXRbdHlwZT1cInJhZGlvXCJdIHtcbiAgICBtYXJnaW46IDAgMC41ZW07XG4gIH1cblxuICAuZmllbGRoZWxwZXJzLWZpZWxkLXJhZGlvLWxhYmVsIHtcbiAgICBkaXNwbGF5OiBibG9jaztcbiAgICBmbG9hdDogbGVmdDtcbiAgICB3aWR0aDogODUlO1xuICAgIGZvbnQtd2VpZ2h0OiBib2xkO1xuICAgIHBhZGRpbmc6IDAgMC41ZW07XG4gICAgYm9yZGVyLWxlZnQ6IDFweCBzb2xpZCAjREZERkRGO1xuICAgIGhlaWdodDogMzBweDtcbiAgICBsaW5lLWhlaWdodDogMzBweDtcbiAgICBib3gtc2l6aW5nOiBib3JkZXItYm94O1xuICB9XG59IiwiLmZpZWxkaGVscGVycy1maWVsZC1yZXBlYXRlci1sYWJlbCB7XG4gIGZvbnQtd2VpZ2h0OiBib2xkO1xufVxuXG4uZmllbGRoZWxwZXJzLWZpZWxkLXJlcGVhdGVyLWxpc3Qge1xuICAuZmllbGRoZWxwZXJzLXNvcnRhYmxlLXBsYWNlaG9sZGVyIHtcbiAgICBib3JkZXI6IDNweCBkYXNoZWQgI2RkZDtcbiAgfVxufVxuXG4uZmllbGRoZWxwZXJzLWZpZWxkLXJlcGVhdGVyLXJvdyB7XG4gIHBhZGRpbmc6IDAuNWVtO1xuICBtYXJnaW46IDAuNWVtIDA7XG4gIGJvcmRlcjogMXB4IHNvbGlkICNkZGQ7XG4gIGJhY2tncm91bmQ6ICNmZmY7XG5cbiAgJjpiZWZvcmUge1xuICAgIGNvbnRlbnQ6ICcnO1xuICAgIGRpc3BsYXk6IHRhYmxlO1xuICAgIGNsZWFyOiBib3RoO1xuICB9XG5cbiAgJi51aS1zb3J0YWJsZS1oZWxwZXIge1xuICAgIG9wYWNpdHk6IDAuNTtcbiAgfVxuXG4gIC5maWVsZGhlbHBlcnMtZmllbGQtcmVwZWF0ZXItaGFuZGxlIHtcbiAgICBoZWlnaHQ6IDIwcHg7XG4gICAgY3Vyc29yOiBtb3ZlO1xuICAgIG1hcmdpbi1ib3R0b206IDEwcHg7XG4gICAgYmFja2dyb3VuZC1pbWFnZTogLXdlYmtpdC1yZXBlYXRpbmctcmFkaWFsLWdyYWRpZW50KGNlbnRlciBjZW50ZXIsIHJnYmEoMCwgMCwgMCwgLjIpLCByZ2JhKDAsIDAsIDAsIC4yKSAxcHgsIHRyYW5zcGFyZW50IDFweCwgdHJhbnNwYXJlbnQgMTAwJSk7XG4gICAgYmFja2dyb3VuZC1pbWFnZTogLW1vei1yZXBlYXRpbmctcmFkaWFsLWdyYWRpZW50KGNlbnRlciBjZW50ZXIsIHJnYmEoMCwgMCwgMCwgLjIpLCByZ2JhKDAsIDAsIDAsIC4yKSAxcHgsIHRyYW5zcGFyZW50IDFweCwgdHJhbnNwYXJlbnQgMTAwJSk7XG4gICAgYmFja2dyb3VuZC1pbWFnZTogLW1zLXJlcGVhdGluZy1yYWRpYWwtZ3JhZGllbnQoY2VudGVyIGNlbnRlciwgcmdiYSgwLCAwLCAwLCAuMiksIHJnYmEoMCwgMCwgMCwgLjIpIDFweCwgdHJhbnNwYXJlbnQgMXB4LCB0cmFuc3BhcmVudCAxMDAlKTtcbiAgICBiYWNrZ3JvdW5kLWltYWdlOiByZXBlYXRpbmctcmFkaWFsLWdyYWRpZW50KGNlbnRlciBjZW50ZXIsIHJnYmEoMCwgMCwgMCwgLjIpLCByZ2JhKDAsIDAsIDAsIC4yKSAxcHgsIHRyYW5zcGFyZW50IDFweCwgdHJhbnNwYXJlbnQgMTAwJSk7XG4gICAgYmFja2dyb3VuZC1zaXplOiAzcHggM3B4O1xuICB9XG59XG5cbi5maWVsZGhlbHBlcnMtZmllbGQtcmVwZWF0ZXItY29sbGFwc2FibGUge1xuICAuZmllbGRoZWxwZXJzLWZpZWxkLXJlcGVhdGVyLWNvbnRlbnQge1xuICAgIGRpc3BsYXk6IG5vbmU7XG4gIH1cblxuICAuZmllbGRoZWxwZXJzLWZpZWxkLXJlcGVhdGVyLWhlYWRlci1pbnRlcmlvciB7XG4gICAgcGFkZGluZzogMCAwLjVlbSAwIDAuNWVtO1xuXG4gICAgLmZpZWxkaGVscGVycy1maWVsZC1yZXBlYXRlci1kZWxldGUtYnV0dG9uIHtcbiAgICAgIGZsb2F0OiByaWdodDtcbiAgICB9XG4gIH1cblxuICAuZmllbGRoZWxwZXJzLWZpZWxkLXJlcGVhdGVyLWNvbGxhcHNhYmxlLWhhbmRsZSB7XG4gICAgY3Vyc29yOiBwb2ludGVyO1xuICB9XG5cbiAgLmZpZWxkaGVscGVycy1maWVsZC1yZXBlYXRlci1yb3cub3BlbmVkIHtcbiAgICAuZmllbGRoZWxwZXJzLWZpZWxkLXJlcGVhdGVyLWNvbGxhcHNhYmxlLWNvbGxhcHNlLWljb257XG4gICAgICB0cmFuc2Zvcm06IHJvdGF0ZSgxODBkZWcpO1xuICAgIH1cbiAgfVxuXG4gIC5maWVsZGhlbHBlcnMtZmllbGQtcmVwZWF0ZXItY29sbGFwc2FibGUtY29sbGFwc2UtaWNvbiB7XG4gICAgdHJhbnNpdGlvbjogdHJhbnNmb3JtIDMwMG1zIGVhc2UtaW4gMHM7XG5cbiAgICAmOmhvdmVyIHtcbiAgICAgIGN1cnNvcjogcG9pbnRlcjtcbiAgICB9XG4gIH1cbn0iLCIuc2VsZWN0Mi1jb250YWluZXItLWRlZmF1bHQgLmZpZWxkaGVscGVycy1zZWxlY3QyIHtcblxuICAmLnNlbGVjdDItc2VsZWN0aW9uLS1zaW5nbGUsXG4gICYuc2VsZWN0Mi1zZWxlY3Rpb24tLW11bHRpcGxlIHtcblxuICAgICYuc2VsZWN0Mi1zZWxlY3Rpb24ge1xuICAgICAgYm9yZGVyLXJhZGl1czogMDtcbiAgICAgIGJvcmRlcjogMXB4IHNvbGlkICNkZGQ7XG4gICAgICBib3gtc2hhZG93OiBpbnNldCAwIDFweCAycHggcmdiYSgjMDAwLCAwLjA3KTtcbiAgICAgIG91dGxpbmU6IG5vbmU7XG4gICAgICBtYXJnaW46IDFweDtcbiAgICAgIGhlaWdodDogYXV0bztcbiAgICB9XG5cbiAgICAuc2VsZWN0Mi1zZWxlY3Rpb25fX3JlbmRlcmVkIHtcbiAgICAgIGxpbmUtaGVpZ2h0OiBpbmhlcml0O1xuICAgICAgcGFkZGluZzogM3B4IDVweDtcbiAgICAgIGZvbnQtc2l6ZTogMTRweDtcbiAgICB9XG5cbiAgICAuc2VsZWN0Mi1zZWFyY2gge1xuICAgICAgbWFyZ2luLWJvdHRvbTogMDtcbiAgICB9XG5cbiAgICAuc2VsZWN0Mi1zZWxlY3Rpb25fX2Nob2ljZSB7XG4gICAgICBib3JkZXItcmFkaXVzOiAwO1xuICAgIH1cblxuICAgIC5zZWxlY3QyLXNlbGVjdGlvbl9fY2xlYXIge1xuICAgICAgbWFyZ2luLXJpZ2h0OiAxNXB4O1xuICAgIH1cbiAgfVxuXG4gICYuc2VsZWN0Mi1kcm9wZG93biB7XG4gICAgYm9yZGVyLXJhZGl1czogMDtcbiAgICBib3JkZXI6IDFweCBzb2xpZCAjZGRkO1xuICAgIGJveC1zaGFkb3c6IDVweCA1cHggNDBweCByZ2JhKCMwMDAsIDAuMyk7XG5cbiAgICAuc2VsZWN0Mi1yZXN1bHRzX19vcHRpb24tLWhpZ2hsaWdodGVkW2FyaWEtc2VsZWN0ZWRdIHtcbiAgICAgIGJhY2tncm91bmQtY29sb3I6ICRwcmltYXJ5LWNvbG9yO1xuICAgIH1cblxuICAgIC5zZWxlY3QyLXJlc3VsdHNfX29wdGlvbiB7XG4gICAgICBtYXJnaW4tYm90dG9tOiAwO1xuICAgIH1cbiAgfVxufSIsIi5maWVsZGhlbHBlcnMtZmllbGQtdGFibGUge1xuXG4gIC5maWVsZGhlbHBlcnMtZmllbGQtdGFibGUtbG9hZGluZyB7XG4gICAgdGV4dC1hbGlnbjogY2VudGVyO1xuXG4gICAgLnNwaW5uZXIge1xuICAgICAgZmxvYXQ6IG5vbmU7XG4gICAgICBkaXNwbGF5OiBpbmxpbmUtYmxvY2s7XG4gICAgfVxuICB9XG5cbiAgdGFibGUge1xuICAgIHdpZHRoOiAxMDAlO1xuICAgIGJvcmRlci1jb2xsYXBzZTogY29sbGFwc2U7XG4gIH1cblxuICB0aCwgdGQge1xuICAgIHBhZGRpbmc6IDVweDtcbiAgfVxuXG4gIHRoZWFkIHtcbiAgICBpbnB1dFt0eXBlPVwidGV4dFwiXSB7XG4gICAgICBiYWNrZ3JvdW5kOiAjZmZmNzhhO1xuICAgIH1cbiAgfVxuXG4gIGlucHV0W3R5cGU9XCJ0ZXh0XCJdIHtcbiAgICB3aWR0aDogMTAwJTtcbiAgfVxuXG4gIC5maWVsZGhlbHBlcnMtZmllbGQtdGFibGUtZGVsZXRlLWNvbHVtbnMge1xuICAgIHRleHQtYWxpZ246IGNlbnRlcjtcbiAgfVxufSIsIi5maWVsZGhlbHBlcnMtZmllbGQtdG9nZ2xlLWNvbnRhaW5lciB7XG4gIHBvc2l0aW9uOiByZWxhdGl2ZTtcbiAgZGlzcGxheTogaW5saW5lLWJsb2NrO1xuICB3aWR0aDogNjBweDtcbiAgaGVpZ2h0OiAzNHB4O1xuXG4gICYuY2hlY2tlZCB7XG4gICAgLmZpZWxkaGVscGVycy1maWVsZC10b2dnbGUtc2xpZGVyIHtcbiAgICAgIGJhY2tncm91bmQtY29sb3I6ICRwcmltYXJ5LWNvbG9yO1xuXG4gICAgICAmOmJlZm9yZSB7XG4gICAgICAgIHRyYW5zZm9ybTogdHJhbnNsYXRlWCgyNnB4KTtcbiAgICAgIH1cbiAgICB9XG4gIH1cblxuICAuZmllbGRoZWxwZXJzLWZpZWxkLXRvZ2dsZS1zbGlkZXIge1xuICAgIHBvc2l0aW9uOiBhYnNvbHV0ZTtcbiAgICBjdXJzb3I6IHBvaW50ZXI7XG4gICAgdG9wOiAwO1xuICAgIGxlZnQ6IDA7XG4gICAgcmlnaHQ6IDA7XG4gICAgYm90dG9tOiAwO1xuICAgIGJhY2tncm91bmQtY29sb3I6ICNjY2M7XG4gICAgdHJhbnNpdGlvbjogdHJhbnNmb3JtIDMwMG1zO1xuXG4gICAgJjpiZWZvcmUge1xuICAgICAgcG9zaXRpb246IGFic29sdXRlO1xuICAgICAgY29udGVudDogXCJcIjtcbiAgICAgIGhlaWdodDogMjZweDtcbiAgICAgIHdpZHRoOiAyNnB4O1xuICAgICAgbGVmdDogNHB4O1xuICAgICAgYm90dG9tOiA0cHg7XG4gICAgICBiYWNrZ3JvdW5kLWNvbG9yOiB3aGl0ZTtcbiAgICAgIHRyYW5zaXRpb246IHRyYW5zZm9ybSAzMDBtcztcbiAgICB9XG4gIH1cbn0iLCIuZmllbGRoZWxwZXJzLWZpZWxkLXd5c2l3eWctbGFiZWwge1xuICBmb250LXdlaWdodDogYm9sZDtcbn0iLCIuZmllbGRoZWxwZXJzLWZpZWxkLXRpcCB7XG4gIHBvc2l0aW9uOiByZWxhdGl2ZTtcbiAgZGlzcGxheTogaW5saW5lLWJsb2NrO1xuXG4gICYuZmllbGRoZWxwZXJzLWZpZWxkLXRpcC1hbGlnbi1sZWZ0IHtcbiAgICAuZmllbGRoZWxwZXJzLWZpZWxkLXRpcC10ZXh0IHtcbiAgICAgIGxlZnQ6IC0xMHB4O1xuXG4gICAgICAmOmJlZm9yZSB7XG4gICAgICAgIGxlZnQ6IDEwcHg7XG4gICAgICB9XG4gICAgfVxuICB9XG5cbiAgJi5maWVsZGhlbHBlcnMtZmllbGQtdGlwLWFsaWduLXJpZ2h0IHtcbiAgICAuZmllbGRoZWxwZXJzLWZpZWxkLXRpcC10ZXh0IHtcbiAgICAgIHJpZ2h0OiAtMTBweDtcblxuICAgICAgJjpiZWZvcmUge1xuICAgICAgICByaWdodDogMTBweDtcbiAgICAgIH1cbiAgICB9XG4gIH1cblxuICAmOmhvdmVyIHtcbiAgICAuZmllbGRoZWxwZXJzLWZpZWxkLXRpcC10ZXh0IHtcbiAgICAgIHZpc2liaWxpdHk6IHZpc2libGU7XG4gICAgICBvcGFjaXR5OiAxO1xuICAgICAgdHJhbnNmb3JtOiB0cmFuc2xhdGVZKDApO1xuICAgIH1cblxuICAgIC5maWVsZGhlbHBlcnMtZmllbGQtdGlwLXRvZ2dsZSB7XG4gICAgICBjb2xvcjogJHByaW1hcnktY29sb3I7XG4gICAgfVxuICB9XG5cbiAgLmZpZWxkaGVscGVycy1maWVsZC10aXAtdG9nZ2xlIHtcbiAgICBjdXJzb3I6IHBvaW50ZXI7XG4gICAgdHJhbnNpdGlvbjogY29sb3IgMzAwbXM7XG4gIH1cblxuICAuZmllbGRoZWxwZXJzLWZpZWxkLXRpcC10ZXh0IHtcbiAgICBwb3NpdGlvbjogYWJzb2x1dGU7XG4gICAgdmlzaWJpbGl0eTogaGlkZGVuO1xuICAgIG9wYWNpdHk6IDA7XG4gICAgdG9wOiAxMDAlO1xuICAgIG1hcmdpbi10b3A6IDE1cHg7XG4gICAgYmFja2dyb3VuZDogJHByaW1hcnktY29sb3I7XG4gICAgY29sb3I6ICNmZmY7XG4gICAgcGFkZGluZzogMWVtO1xuICAgIHdpZHRoOiAzMDBweDtcbiAgICB0ZXh0LWFsaWduOiBsZWZ0O1xuICAgIGJveC1zaGFkb3c6IDVweCA1cHggNDBweCByZ2JhKCMwMDAsIDAuMyk7XG4gICAgdHJhbnNmb3JtOiB0cmFuc2xhdGVZKDEwcHgpO1xuICAgIHRyYW5zaXRpb246IHZpc2liaWxpdHkgMzAwbXMsIG9wYWNpdHkgMzAwbXMsIHRyYW5zZm9ybSAzMDBtcztcbiAgICB6LWluZGV4OiAxMDA7XG5cbiAgICAmOmJlZm9yZSB7XG4gICAgICBjb250ZW50OiAnJztcbiAgICAgIHBvc2l0aW9uOiBhYnNvbHV0ZTtcbiAgICAgIGJvdHRvbTogMTAwJTtcbiAgICAgIHdpZHRoOiAwO1xuICAgICAgaGVpZ2h0OiAwO1xuICAgICAgYm9yZGVyLXN0eWxlOiBzb2xpZDtcbiAgICAgIGJvcmRlci13aWR0aDogMCAxMHB4IDEwcHggMTBweDtcbiAgICAgIGJvcmRlci1jb2xvcjogdHJhbnNwYXJlbnQgdHJhbnNwYXJlbnQgJHByaW1hcnktY29sb3IgdHJhbnNwYXJlbnQ7XG4gICAgfVxuXG4gICAgJjphZnRlciB7XG4gICAgICBjb250ZW50OiAnJztcbiAgICAgIHBvc2l0aW9uOiBhYnNvbHV0ZTtcbiAgICAgIGJvdHRvbTogMTAwJTtcbiAgICAgIGxlZnQ6IDA7XG4gICAgICB3aWR0aDogMTAwJTtcbiAgICAgIGhlaWdodDogMTVweDtcbiAgICB9XG5cbiAgICBhIHtcbiAgICAgIGNvbG9yOiBpbmhlcml0ICFpbXBvcnRhbnQ7XG4gICAgICB0ZXh0LWRlY29yYXRpb246IHVuZGVybGluZTtcbiAgICB9XG4gIH1cbn0iXX0= */

--- a/assets/dist/js/rbm-field-helpers-admin.min.js
+++ b/assets/dist/js/rbm-field-helpers-admin.min.js
@@ -1,1 +1,3795 @@
-!function(e){function t(n){if(i[n])return i[n].exports;var r=i[n]={i:n,l:!1,exports:{}};return e[n].call(r.exports,r,r.exports,t),r.l=!0,r.exports}var i={};t.m=e,t.c=i,t.d=function(e,i,n){t.o(e,i)||Object.defineProperty(e,i,{configurable:!1,enumerable:!0,get:n})},t.n=function(e){var i=e&&e.__esModule?function(){return e.default}:function(){return e};return t.d(i,"a",i),i},t.o=function(e,t){return Object.prototype.hasOwnProperty.call(e,t)},t.p="",t(t.s=2)}([function(e,t,i){"use strict";function n(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}Object.defineProperty(t,"__esModule",{value:!0});var r=function(){function e(e,t){for(var i=0;i<t.length;i++){var n=t[i];n.enumerable=n.enumerable||!1,n.configurable=!0,"value"in n&&(n.writable=!0),Object.defineProperty(e,n.key,n)}}return function(t,i,n){return i&&e(t.prototype,i),n&&e(t,n),t}}(),o=function(){function e(t,i){n(this,e),this.$field=t,this.$wrapper=t.closest(".fieldhelpers-field"),this.type=i,this.name=this.$wrapper.attr("data-fieldhelpers-name"),this.instance=this.$wrapper.attr("data-fieldhelpers-instance"),this.getRepeater(),this.getOptions(),this.repeater&&this.repeaterSupport()}return r(e,[{key:"initField",value:function(){}},{key:"getOptions",value:function(){if(this.options={},void 0!==RBM_FieldHelpers[this.instance])if(this.repeater){if(void 0===RBM_FieldHelpers[this.instance].repeaterFields[this.repeater])return void console.error("Field Helpers Error: Data for repeater "+this.type+" sub-fields cannot be found.");if(void 0===RBM_FieldHelpers[this.instance].repeaterFields[this.repeater][this.name])return void console.error("Field Helpers Error: Cannot find field options for repeater "+this.type+" sub-field with name: "+this.name+".");this.options=RBM_FieldHelpers[this.instance].repeaterFields[this.repeater][this.name]}else{if(void 0===RBM_FieldHelpers[this.instance][this.type])return void console.error("Field Helpers Error: Data for "+this.type+" fields cannot be found.");if(void 0===RBM_FieldHelpers[this.instance][this.type][this.name])return void console.error("Field Helpers Error: Cannot find field options for "+this.type+" field with name: "+this.name+".");this.options=RBM_FieldHelpers[this.instance][this.type][this.name]}else console.error("Field Helpers Error: Data for "+this.instance+" instance cannot be found.")}},{key:"getRepeater",value:function(){this.$field.closest("[data-fieldhelpers-field-repeater]").length&&(this.$repeater=this.$field.parent().closest("[data-fieldhelpers-field-repeater]"),this.repeater=this.$repeater.closest(".fieldhelpers-field-repeater").attr("data-fieldhelpers-name"))}},{key:"repeaterSupport",value:function(){var e=this;this.$repeater.on("repeater-init",function(){e.repeaterOnInit()}),this.$repeater.on("repeater-before-add-item",function(){e.repeaterBeforeAddItem()}),this.$repeater.on("repeater-add-item",function(){e.repeaterOnAddItem()}),this.$field.closest("[data-repeater-item]").on("repeater-before-delete-item",function(){e.repeaterBeforeDeleteSelf()}),this.$repeater.on("repeater-before-delete-item",function(){e.repeaterBeforeDeleteItem()}),this.$repeater.on("repeater-delete-item",function(){e.repeaterOnDeleteItem()}),this.$repeater.find(".fieldhelpers-field-repeater-list").on("list-update",function(){e.repeaterOnSort()}),this.repeaterSetID(),this.fieldCleanup()}},{key:"repeaterOnInit",value:function(){}},{key:"repeaterBeforeAddItem",value:function(){}},{key:"repeaterOnAddItem",value:function(){}},{key:"repeaterBeforeDeleteSelf",value:function(){}},{key:"repeaterBeforeDeleteItem",value:function(){}},{key:"repeaterOnDeleteItem",value:function(){}},{key:"repeaterOnSort",value:function(){}},{key:"repeaterSetID",value:function(){var e=this.$field.closest("[data-repeater-item]").index(),t=this.options.id+"_"+e;this.$field.attr("id",t)}},{key:"fieldCleanup",value:function(){}},{key:"setDefault",value:function(){this.options.default&&this.$field.val(this.options.default).change()}}]),e}();t.default=o},function(e,t,i){"use strict";function n(e){return e&&e.__esModule?e:{default:e}}function r(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}Object.defineProperty(t,"__esModule",{value:!0});var o=n(i(4)),a=n(i(5)),l=n(i(6)),s=n(i(7)),u=n(i(8)),f=n(i(9)),c=n(i(10)),d=n(i(11)),p=n(i(12)),h=n(i(13)),y=n(i(14)),b=n(i(15)),v=n(i(16)),m=n(i(17));t.default=function e(t){r(this,e),this.fields={checkbox:new b.default(t),toggle:new m.default(t),radio:new v.default(t),select:new h.default(t),textarea:new y.default(t),number:new o.default(t),colorpicker:new a.default(t),datepicker:new l.default(t),timepicker:new s.default(t),datetimepicker:new u.default(t),table:new f.default(t),media:new c.default(t),list:new d.default(t),repeater:new p.default(t)}}},function(e,t,i){e.exports=i(3)},function(e,t,i){"use strict";var n=function(e){return e&&e.__esModule?e:{default:e}}(i(1));jQuery(function(){new n.default(jQuery(document))})},function(e,t,i){"use strict";function n(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}function r(e,t){if(!e)throw new ReferenceError("this hasn't been initialised - super() hasn't been called");return!t||"object"!=typeof t&&"function"!=typeof t?e:t}function o(e,t){if("function"!=typeof t&&null!==t)throw new TypeError("Super expression must either be null or a function, not "+typeof t);e.prototype=Object.create(t&&t.prototype,{constructor:{value:e,enumerable:!1,writable:!0,configurable:!0}}),t&&(Object.setPrototypeOf?Object.setPrototypeOf(e,t):e.__proto__=t)}Object.defineProperty(t,"__esModule",{value:!0});var a=function(){function e(e,t){for(var i=0;i<t.length;i++){var n=t[i];n.enumerable=n.enumerable||!1,n.configurable=!0,"value"in n&&(n.writable=!0),Object.defineProperty(e,n.key,n)}}return function(t,i,n){return i&&e(t.prototype,i),n&&e(t,n),t}}(),l=function(e){return e&&e.__esModule?e:{default:e}}(i(0)),s=function(e){function t(e){n(this,t);var i=r(this,(t.__proto__||Object.getPrototypeOf(t)).call(this,e,"number"));return i.initField(),i}return o(t,l.default),a(t,[{key:"initField",value:function(){this.$ui={container:this.$field,input:this.$field.find(".fieldhelpers-field-input"),increase:this.$field.find("[data-number-increase]"),decrease:this.$field.find("[data-number-decrease]")},this.intervals={increase:{normal:parseInt(this.options.increaseInterval),alt:parseInt(this.options.altIncreaseInterval)},decrease:{normal:parseInt(this.options.decreaseInterval),alt:parseInt(this.options.altDecreaseInterval)}};var e=this.options.max,t=this.options.min;this.constraints={max:"none"!==e&&parseInt(e),min:"none"!==t&&parseInt(t)},this.shiftKeyUtility(),this.setupHandlers();var i=this.$ui.input.val();this.value=i?parseInt(i):0,this.validateInput()}},{key:"shiftKeyUtility",value:function(){var e=this;this.shiftKeyDown=!1,jQuery(document).on("keydown",function(t){16===t.which&&(e.shiftKeyDown=!0)}),jQuery(document).on("keyup",function(t){16===t.which&&(e.shiftKeyDown=!1)})}},{key:"setupHandlers",value:function(){var e=this;this.$ui.increase.click(function(t){e.increaseNumber(t)}),this.$ui.decrease.click(function(t){e.decreaseNumber(t)}),this.$ui.input.change(function(t){e.inputExternalChange(t)})}},{key:"increaseNumber",value:function(){var e=this.shiftKeyDown?this.intervals.increase.alt:this.intervals.increase.normal,t=this.value+e;this.$ui.input.val(t),this.$ui.input.trigger("change")}},{key:"decreaseNumber",value:function(){var e=this.shiftKeyDown?this.intervals.decrease.alt:this.intervals.decrease.normal,t=this.value-e;this.$ui.input.val(t),this.$ui.input.trigger("change")}},{key:"inputExternalChange",value:function(){this.validateInput()}},{key:"constrainNumber",value:function(e){var t="unmodified";return!1!==this.constraints.max&&e>this.constraints.max?(t="max",e=this.constraints.max):!1!==this.constraints.min&&e<this.constraints.min&&(t="min",e=this.constraints.min),{status:t,number:e}}},{key:"validateInput",value:function(){var e=this.$ui.input.val(),t=e.match(/^-?[0-9]\d*(\.\d+)?$/);e=t&&parseInt(t[0])||0;var i=this.constrainNumber(e);switch(i.status){case"max":this.toggleDecreaseDisabledUI(!0),this.toggleIncreaseDisabledUI(!1);break;case"min":this.toggleIncreaseDisabledUI(!0),this.toggleDecreaseDisabledUI(!1);break;default:this.toggleIncreaseDisabledUI(!0),this.toggleDecreaseDisabledUI(!0)}this.value=i.number,this.$ui.input.val(this.value),e!==this.value&&this.$ui.input.trigger("change")}},{key:"toggleIncreaseDisabledUI",value:function(e){this.$ui.increase.prop("disabled",!e)}},{key:"toggleDecreaseDisabledUI",value:function(e){this.$ui.decrease.prop("disabled",!e)}}]),t}(),u=function(){function e(t){n(this,e);var i=this;this.fields=[];var r=t.find("[data-fieldhelpers-field-number]");r.length&&r.each(function(){i.initializeField(jQuery(this))})}return a(e,[{key:"initializeField",value:function(e){this.fields.push({$field:e,api:new s(e)})}}]),e}();t.default=u},function(e,t,i){"use strict";function n(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}function r(e,t){if(!e)throw new ReferenceError("this hasn't been initialised - super() hasn't been called");return!t||"object"!=typeof t&&"function"!=typeof t?e:t}function o(e,t){if("function"!=typeof t&&null!==t)throw new TypeError("Super expression must either be null or a function, not "+typeof t);e.prototype=Object.create(t&&t.prototype,{constructor:{value:e,enumerable:!1,writable:!0,configurable:!0}}),t&&(Object.setPrototypeOf?Object.setPrototypeOf(e,t):e.__proto__=t)}Object.defineProperty(t,"__esModule",{value:!0});var a=function(){function e(e,t){for(var i=0;i<t.length;i++){var n=t[i];n.enumerable=n.enumerable||!1,n.configurable=!0,"value"in n&&(n.writable=!0),Object.defineProperty(e,n.key,n)}}return function(t,i,n){return i&&e(t.prototype,i),n&&e(t,n),t}}(),l=function(e){return e&&e.__esModule?e:{default:e}}(i(0)),s=function(e){function t(e){n(this,t);var i=r(this,(t.__proto__||Object.getPrototypeOf(t)).call(this,e,"colorpicker"));return i.initializeColorpicker(),i}return o(t,l.default),a(t,[{key:"initializeColorpicker",value:function(){this.$field.wpColorPicker()}},{key:"fieldCleanup",value:function(){this.$wrapper.find("[data-fieldhelpers-field-colorpicker]").appendTo(this.$wrapper.find(".fieldhelpers-field-content")),this.$wrapper.find(".wp-picker-container").remove()}}]),t}(),u=function(){function e(t){n(this,e);var i=this;this.fields=[];var r=t.find("[data-fieldhelpers-field-colorpicker]");if(r.length){if(!jQuery.isFunction(jQuery.fn.wpColorPicker))return void console.error('Field Helpers Error: Trying to initialize Color Picker field but "wp-color-picker" is not enqueued.');r.each(function(){i.initializeField(jQuery(this))})}}return a(e,[{key:"initializeField",value:function(e){this.fields.push({$field:e,api:new s(e)})}}]),e}();t.default=u},function(e,t,i){"use strict";function n(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}function r(e,t){if(!e)throw new ReferenceError("this hasn't been initialised - super() hasn't been called");return!t||"object"!=typeof t&&"function"!=typeof t?e:t}function o(e,t){if("function"!=typeof t&&null!==t)throw new TypeError("Super expression must either be null or a function, not "+typeof t);e.prototype=Object.create(t&&t.prototype,{constructor:{value:e,enumerable:!1,writable:!0,configurable:!0}}),t&&(Object.setPrototypeOf?Object.setPrototypeOf(e,t):e.__proto__=t)}Object.defineProperty(t,"__esModule",{value:!0});var a=function(){function e(e,t){for(var i=0;i<t.length;i++){var n=t[i];n.enumerable=n.enumerable||!1,n.configurable=!0,"value"in n&&(n.writable=!0),Object.defineProperty(e,n.key,n)}}return function(t,i,n){return i&&e(t.prototype,i),n&&e(t,n),t}}(),l=function(e){return e&&e.__esModule?e:{default:e}}(i(0)),s=function(e){function t(e){n(this,t);var i=r(this,(t.__proto__||Object.getPrototypeOf(t)).call(this,e,"datepicker"));return i.initField(),i}return o(t,l.default),a(t,[{key:"initField",value:function(){var e=this;this.$hiddenField=this.$field.next('input[type="hidden"]');var t=["beforeShow","beforeShowDay","calculateWeek","onChangeMonthYear","onClose","onSelect"];jQuery.each(this.options.datepickerOptions,function(i,n){-1!==t.indexOf(i)&&!jQuery.isFunction(e.options.datepickerOptions[i])&&jQuery.isFunction(window[n])&&(e.options.datepickerOptions[i]=window[n])}),this.options.datepickerOptions.altField=this.$hiddenField,this.$field.datepicker(this.options.datepickerOptions)}},{key:"fieldCleanup",value:function(){this.$field.removeClass("hasDatepicker").removeAttr("id")}}]),t}(),u=function(){function e(t){n(this,e);var i=this;this.fields=[];var r=t.find("[data-fieldhelpers-field-datepicker]");if(r.length){if(!jQuery.isFunction(jQuery.fn.datepicker))return void console.error('Field Helpers Error: Trying to initialize Date Picker field but "jquery-ui-datepicker" is not enqueued.');r.each(function(){i.initializeField(jQuery(this))})}}return a(e,[{key:"initializeField",value:function(e){this.fields.push({$field:e,api:new s(e)})}}]),e}();t.default=u},function(e,t,i){"use strict";function n(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}function r(e,t){if(!e)throw new ReferenceError("this hasn't been initialised - super() hasn't been called");return!t||"object"!=typeof t&&"function"!=typeof t?e:t}function o(e,t){if("function"!=typeof t&&null!==t)throw new TypeError("Super expression must either be null or a function, not "+typeof t);e.prototype=Object.create(t&&t.prototype,{constructor:{value:e,enumerable:!1,writable:!0,configurable:!0}}),t&&(Object.setPrototypeOf?Object.setPrototypeOf(e,t):e.__proto__=t)}Object.defineProperty(t,"__esModule",{value:!0});var a=function(){function e(e,t){for(var i=0;i<t.length;i++){var n=t[i];n.enumerable=n.enumerable||!1,n.configurable=!0,"value"in n&&(n.writable=!0),Object.defineProperty(e,n.key,n)}}return function(t,i,n){return i&&e(t.prototype,i),n&&e(t,n),t}}(),l=function(e){return e&&e.__esModule?e:{default:e}}(i(0)),s=function(e){function t(e){n(this,t);var i=r(this,(t.__proto__||Object.getPrototypeOf(t)).call(this,e,"timepicker"));return i.initField(),i}return o(t,l.default),a(t,[{key:"initField",value:function(){var e=this;this.$hiddenField=this.$field.next('input[type="hidden"]');var t=["beforeShow","beforeShowDay","calculateWeek","onChangeMonthYear","onClose","onSelect"],i={};RBM_FieldHelpers["datepicker_args_"+name]&&(i=RBM_FieldHelpers["datepicker_args_"+name]),jQuery.each(this.options.timepickerOptions,function(i,n){-1!==t.indexOf(i)&&!jQuery.isFunction(e.options.timepickerOptions[i])&&jQuery.isFunction(window[n])&&(e.options.timepickerOptions[i]=window[n])}),i.altField=this.$hiddenField,this.$field.timepicker(this.options.timepickerOptions)}},{key:"fieldCleanup",value:function(){this.$field.removeClass("hasDatepicker").removeAttr("id")}}]),t}(),u=function(){function e(t){n(this,e);var i=this;this.fields=[];var r=t.find("[data-fieldhelpers-field-timepicker]");if(r.length){if(!jQuery.isFunction(jQuery.fn.timepicker))return void console.error('Field Helpers Error: Trying to initialize Time Picker field but "jquery-ui-datetimepicker" is not enqueued.');r.each(function(){i.initializeField(jQuery(this))})}}return a(e,[{key:"initializeField",value:function(e){this.fields.push({$field:e,api:new s(e)})}}]),e}();t.default=u},function(e,t,i){"use strict";function n(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}function r(e,t){if(!e)throw new ReferenceError("this hasn't been initialised - super() hasn't been called");return!t||"object"!=typeof t&&"function"!=typeof t?e:t}function o(e,t){if("function"!=typeof t&&null!==t)throw new TypeError("Super expression must either be null or a function, not "+typeof t);e.prototype=Object.create(t&&t.prototype,{constructor:{value:e,enumerable:!1,writable:!0,configurable:!0}}),t&&(Object.setPrototypeOf?Object.setPrototypeOf(e,t):e.__proto__=t)}Object.defineProperty(t,"__esModule",{value:!0});var a=function(){function e(e,t){for(var i=0;i<t.length;i++){var n=t[i];n.enumerable=n.enumerable||!1,n.configurable=!0,"value"in n&&(n.writable=!0),Object.defineProperty(e,n.key,n)}}return function(t,i,n){return i&&e(t.prototype,i),n&&e(t,n),t}}(),l=function(e){return e&&e.__esModule?e:{default:e}}(i(0)),s=function(e){function t(e){n(this,t);var i=r(this,(t.__proto__||Object.getPrototypeOf(t)).call(this,e,"datetimepicker"));return i.initField(),i}return o(t,l.default),a(t,[{key:"initField",value:function(){var e=this;this.$hiddenField=this.$field.next('input[type="hidden"]');var t=["beforeShow","beforeShowDay","calculateWeek","onChangeMonthYear","onClose","onSelect"];jQuery.each(this.options.datetimepickerOptions,function(i,n){-1!==t.indexOf(i)&&!jQuery.isFunction(e.options.datetimepickerOptions[i])&&jQuery.isFunction(window[n])&&(e.options.datetimepickerOptions[i]=window[n])}),this.options.datetimepickerOptions.altField=this.$hiddenField,this.$field.datetimepicker(this.options)}},{key:"fieldCleanup",value:function(){this.$field.removeClass("hasDatepicker").removeAttr("id")}}]),t}(),u=function(){function e(t){n(this,e);var i=this;this.fields=[];var r=t.find("[data-fieldhelpers-field-datetimepicker]");if(r.length){if(!jQuery.isFunction(jQuery.fn.datetimepicker))return void console.error('Field Helpers Error: Trying to initialize Date Time Picker field but "rbm-fh-jquery-ui-datetimepicker" is not enqueued.');r.each(function(){i.initializeField(jQuery(this))})}}return a(e,[{key:"initializeField",value:function(e){this.fields.push({$field:e,api:new s(e)})}}]),e}();t.default=u},function(e,t,i){"use strict";function n(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}function r(e,t){if(!e)throw new ReferenceError("this hasn't been initialised - super() hasn't been called");return!t||"object"!=typeof t&&"function"!=typeof t?e:t}function o(e,t){if("function"!=typeof t&&null!==t)throw new TypeError("Super expression must either be null or a function, not "+typeof t);e.prototype=Object.create(t&&t.prototype,{constructor:{value:e,enumerable:!1,writable:!0,configurable:!0}}),t&&(Object.setPrototypeOf?Object.setPrototypeOf(e,t):e.__proto__=t)}Object.defineProperty(t,"__esModule",{value:!0});var a=function(){function e(e,t){for(var i=0;i<t.length;i++){var n=t[i];n.enumerable=n.enumerable||!1,n.configurable=!0,"value"in n&&(n.writable=!0),Object.defineProperty(e,n.key,n)}}return function(t,i,n){return i&&e(t.prototype,i),n&&e(t,n),t}}(),l=function(e){return e&&e.__esModule?e:{default:e}}(i(0)),s=function(e){function t(e){n(this,t);var i=r(this,(t.__proto__||Object.getPrototypeOf(t)).call(this,e,"table"));return i.initField(),i}return o(t,l.default),a(t,[{key:"initField",value:function(){this.$ui={actions:this.$field.find(".fieldhelpers-field-table-actions"),loading:this.$field.find(".fieldhelpers-field-table-loading"),table:this.$field.find("table"),thead:this.$field.find("thead"),tbody:this.$field.find("tbody"),addRow:this.$field.find("[data-table-create-row]"),addColumn:this.$field.find("[data-table-create-column]")},this.l10n=RBM_FieldHelpers.l10n.field_table||{},this.name=this.$field.attr("data-table-name");var e=JSON.parse(this.$ui.table.attr("data-table-data"));this.data={},this.data.head=e.head||[],this.data.body=e.body||[],this.setupHandlers(),this.buildTable(),this.$ui.table.show(),this.$ui.actions.show(),this.$ui.loading.hide()}},{key:"setupHandlers",value:function(){var e=this,t=this;this.$ui.addRow.click(function(t){t.preventDefault(),e.addRow()}),this.$ui.addColumn.click(function(t){t.preventDefault(),e.addColumn()}),this.$ui.table.on("click","[data-delete-row]",function(e){var i=jQuery(this).closest("tr").index();t.deleteRow(i)}),this.$ui.table.on("click","[data-delete-column]",function(e){var i=jQuery(this).closest("td").index();t.deleteColumn(i)}),this.$ui.table.on("change",'input[type="text"]',function(t){e.updateTableData()})}},{key:"updateTableData",value:function(){var e=this,t=[],i=0;this.$ui.table.find("thead th").each(function(){var n=jQuery(this).find('input[name="'+e.name+"[head]["+i+']"]');if(!n.length)return console.error("Field Helpers Error: Table head data corrupted."),!1;t.push(n.val()),i++}),this.data.head=t;var n=[],r=0;this.$ui.table.find("tbody tr").each(function(){if(jQuery(this).hasClass("fieldhelpers-field-table-delete-columns"))return!0;var t=[],i=0;jQuery(this).find("td").each(function(){if(jQuery(this).hasClass("fieldhelpers-field-table-delete-row"))return!0;var n=jQuery(this).find('input[name="'+e.name+"[body]["+r+"]["+i+']"]');if(!n.length)return console.error("Field Helpers Error: Table body data corrupted."),!1;t.push(n.val()),i++}),n.push(t),r++}),this.data.body=n}},{key:"addRow",value:function(){if(this.data.head.length||this.data.head.push(""),this.data.body.length){for(var e=this.data.body[0].length,t=[],i=0;i<e;i++)t.push("");this.data.body.push(t)}else this.data.body.push([""]);this.buildTable()}},{key:"addColumn",value:function(){this.data.body.length?(this.data.head.push(""),this.data.body.map(function(e){e.push("")})):(this.data.head.push([""]),this.data.body.push([""])),this.buildTable()}},{key:"deleteRow",value:function(e){e--,1===this.data.body.length?(this.data.head=[],this.data.body=[]):this.data.body.splice(e,1),this.buildTable()}},{key:"deleteColumn",value:function(e){1===this.data.body[0].length?(this.data.head=[],this.data.body=[]):(this.data.head.splice(e,1),this.data.body.map(function(t){return t.splice(e,1)})),this.buildTable()}},{key:"buildTable",value:function(){var e=this;if(this.$ui.thead.html(""),this.$ui.tbody.html(""),this.data.head.length){var t=jQuery("<tr />");this.data.head.map(function(i,n){var r=jQuery("<th />");r.append('<input type="text" name="'+e.name+"[head]["+n+']" />'),r.find('input[type="text"]').val(i),t.append(r)}),this.$ui.thead.append(t)}if(this.data.body.length){for(var i=jQuery('<tr class="fieldhelpers-field-table-delete-columns"></tr>'),n=0;n<this.data.body[0].length;n++)i.append('<td><button type="button" data-delete-column aria-label="'+this.l10n.delete_column+'"><span class="dashicons dashicons-no" /></button></td>');this.$ui.tbody.append(i),this.data.body.map(function(t,i){var n=jQuery("<tr/>");t.map(function(t,r){var o=jQuery("<td/>");o.append('<input type="text" name="'+e.name+"[body]["+i+"]["+r+']" />'),o.find('input[type="text"]').val(t),n.append(o)}),n.append('<td class="fieldhelpers-field-table-delete-row"><button type="button" data-delete-row aria-label="'+e.l10n.delete_row+'"><span class="dashicons dashicons-no" /></button></td>'),e.$ui.tbody.append(n)})}}}]),t}(),u=function(){function e(t){n(this,e);var i=this;this.fields=[];var r=t.find("[data-fieldhelpers-field-table]");r.length&&r.each(function(){i.initializeField(jQuery(this))})}return a(e,[{key:"initializeField",value:function(e){this.fields.push({$field:e,api:new s(e)})}}]),e}();t.default=u},function(e,t,i){"use strict";function n(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}function r(e,t){if(!e)throw new ReferenceError("this hasn't been initialised - super() hasn't been called");return!t||"object"!=typeof t&&"function"!=typeof t?e:t}function o(e,t){if("function"!=typeof t&&null!==t)throw new TypeError("Super expression must either be null or a function, not "+typeof t);e.prototype=Object.create(t&&t.prototype,{constructor:{value:e,enumerable:!1,writable:!0,configurable:!0}}),t&&(Object.setPrototypeOf?Object.setPrototypeOf(e,t):e.__proto__=t)}Object.defineProperty(t,"__esModule",{value:!0});var a=function(){function e(e,t){for(var i=0;i<t.length;i++){var n=t[i];n.enumerable=n.enumerable||!1,n.configurable=!0,"value"in n&&(n.writable=!0),Object.defineProperty(e,n.key,n)}}return function(t,i,n){return i&&e(t.prototype,i),n&&e(t,n),t}}(),l=function(e){return e&&e.__esModule?e:{default:e}}(i(0)),s=function(e){function t(e){n(this,t);var i=r(this,(t.__proto__||Object.getPrototypeOf(t)).call(this,e,"media"));return i.initField(),i}return o(t,l.default),a(t,[{key:"initField",value:function(){this.$ui={input:this.$field.find("[data-media-input]"),addButton:this.$field.find("[data-add-media]"),imagePreview:this.$field.find("[data-image-preview]"),mediaPreview:this.$field.find("[data-media-preview]"),removeButton:this.$field.find("[data-remove-media]")},this.mediaFrame=wp.media.frames.meta_image_frame=wp.media({title:this.options.l10n.window_title}),this.placeholder=this.options.placeholder,this.type=this.options.type,this.imageProperties={previewSize:this.options.previewSize},this.setupHandlers()}},{key:"setupHandlers",value:function(){var e=this;this.$ui.addButton.click(function(t){t.preventDefault(),e.addMedia()}),this.$ui.removeButton.click(function(t){t.preventDefault(),e.removeMedia()}),this.mediaFrame.on("select",function(t){e.selectMedia()})}},{key:"addMedia",value:function(){this.mediaFrame.open()}},{key:"removeMedia",value:function(){switch(this.$ui.addButton.show(),this.$ui.removeButton.hide(),this.$ui.input.val(""),this.type){case"image":this.$ui.imagePreview.attr("src",this.placeholder||"");break;default:this.$ui.mediaPreview.html(this.placeholder||"&nbsp;")}}},{key:"selectMedia",value:function(){var e=this.mediaFrame.state().get("selection").first().toJSON();switch(this.$ui.input.val(e.id),this.$ui.addButton.hide(),this.$ui.removeButton.show(),this.type){case"image":var t=e.url;e.sizes[this.imageProperties.previewSize]&&(t=e.sizes[this.imageProperties.previewSize].url),this.$ui.imagePreview.attr("src",t);break;default:this.$ui.mediaPreview.html(e.url)}}}]),t}(),u=function(){function e(t){n(this,e);var i=this;this.fields=[];var r=t.find("[data-fieldhelpers-field-media]");if(r.length){if(!wp.media)return void console.error("Field Helpers Error: Trying to initialize Media field but media is not enqueued.");r.each(function(){i.initializeField(jQuery(this))})}}return a(e,[{key:"initializeField",value:function(e){this.fields.push({$field:e,api:new s(e)})}}]),e}();t.default=u},function(e,t,i){"use strict";function n(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}function r(e,t){if(!e)throw new ReferenceError("this hasn't been initialised - super() hasn't been called");return!t||"object"!=typeof t&&"function"!=typeof t?e:t}function o(e,t){if("function"!=typeof t&&null!==t)throw new TypeError("Super expression must either be null or a function, not "+typeof t);e.prototype=Object.create(t&&t.prototype,{constructor:{value:e,enumerable:!1,writable:!0,configurable:!0}}),t&&(Object.setPrototypeOf?Object.setPrototypeOf(e,t):e.__proto__=t)}Object.defineProperty(t,"__esModule",{value:!0});var a=function(){function e(e,t){for(var i=0;i<t.length;i++){var n=t[i];n.enumerable=n.enumerable||!1,n.configurable=!0,"value"in n&&(n.writable=!0),Object.defineProperty(e,n.key,n)}}return function(t,i,n){return i&&e(t.prototype,i),n&&e(t,n),t}}(),l=function(e){return e&&e.__esModule?e:{default:e}}(i(0)),s=function(e){function t(e){n(this,t);var i=r(this,(t.__proto__||Object.getPrototypeOf(t)).call(this,e,"list"));return i.initField(),i}return o(t,l.default),a(t,[{key:"initField",value:function(){this.$field.sortable(this.options)}}]),t}(),u=function(){function e(t){n(this,e);var i=this;this.fields=[];var r=t.find("[data-fieldhelpers-field-list]");if(r.length){if(!jQuery.isFunction(jQuery.fn.sortable))return void console.error('Field Helpers Error: Trying to initialize List field but "jquery-ui-sortable" is not enqueued.');r.each(function(){i.initializeField(jQuery(this))})}}return a(e,[{key:"initializeField",value:function(e){this.fields.push({$field:e,api:new s(e)})}}]),e}();t.default=u},function(e,t,i){"use strict";function n(e){return e&&e.__esModule?e:{default:e}}function r(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}function o(e,t){if(!e)throw new ReferenceError("this hasn't been initialised - super() hasn't been called");return!t||"object"!=typeof t&&"function"!=typeof t?e:t}function a(e,t){if("function"!=typeof t&&null!==t)throw new TypeError("Super expression must either be null or a function, not "+typeof t);e.prototype=Object.create(t&&t.prototype,{constructor:{value:e,enumerable:!1,writable:!0,configurable:!0}}),t&&(Object.setPrototypeOf?Object.setPrototypeOf(e,t):e.__proto__=t)}Object.defineProperty(t,"__esModule",{value:!0});var l=function(){function e(e,t){for(var i=0;i<t.length;i++){var n=t[i];n.enumerable=n.enumerable||!1,n.configurable=!0,"value"in n&&(n.writable=!0),Object.defineProperty(e,n.key,n)}}return function(t,i,n){return i&&e(t.prototype,i),n&&e(t,n),t}}(),s=n(i(0)),u=n(i(1)),f=function(e){function t(e){r(this,t);var i=o(this,(t.__proto__||Object.getPrototypeOf(t)).call(this,e,"repeater"));return i.initField(),i}return a(t,s.default),l(t,[{key:"initField",value:function(){var e=this;this.$repeaterList=this.$field.find(".fieldhelpers-field-repeater-list");var t=this;if(this.$field.repeater({show:function(){t.repeaterShow(jQuery(this))},hide:function(e){t.repeaterHide(jQuery(this),e)},ready:function(e){t.$repeaterList.on("sortupdate",e)},isFirstItemUndeletable:t.options.isFirstItemUndeletable}),!this.options.isFirstItemUndeletable&&this.options.empty&&this.$repeaterList.find(".fieldhelpers-field-repeater-row").remove(),this.options.collapsable&&this.initCollapsable(),this.options.sortable){if(!jQuery.isFunction(jQuery.fn.sortable))return void console.error('Field Helpers Error: Trying to initialize sortable Repeater field but "jquery-ui-sortable" is not enqueued.');this.initSortable()}setTimeout(function(){e.$field.trigger("repeater-init",[e.$field])},1)}},{key:"initCollapsable",value:function(){var e=this;this.$field.on("click touchend","[data-repeater-collapsable-handle]",function(){console.log("click"),e.toggleCollapse(jQuery(this).closest(".fieldhelpers-field-repeater-row"))})}},{key:"initSortable",value:function(){var e=this;this.$repeaterList.sortable({axis:"y",handle:".fieldhelpers-field-repeater-handle",forcePlaceholderSize:!0,placeholder:"fieldhelpers-sortable-placeholder",stop:function(t,i){e.$repeaterList.trigger("list-update",[e.$repeaterList])}})}},{key:"toggleCollapse",value:function(e){var t=e.find(".fieldhelpers-field-repeater-content").first();"opening"===(e.hasClass("opened")?"closing":"opening")?(t.stop().slideDown(),e.addClass("opened"),e.removeClass("closed")):(t.stop().slideUp(),e.addClass("closed"),e.removeClass("opened"))}},{key:"repeaterShow",value:function(e){this.$field.trigger("repeater-before-add-item",[e]),e.slideDown(),this.$repeaterList.hasClass("collapsable")&&(e.addClass("opened").removeClass("closed"),e.find(".fieldhelpers-field-repeater-header span.collapsable-title").html(e.find(".fieldhelpers-field-repeater-header span.collapsable-title").data("collapsable-title-default")),e.find(".collapse-icon").css({transform:"rotate(-180deg)"})),new u.default(e),this.$field.trigger("repeater-add-item",[e])}},{key:"repeaterHide",value:function(e,t){var i=this;confirm(this.options.l10n.confirm_delete_text)&&(this.$field.trigger("repeater-before-delete-item",[e]),e.slideUp(400,function(){t(),i.$field.trigger("repeater-delete-item",[e])}))}}]),t}(),c=function(){function e(t){r(this,e);var i=this;this.fields=[];var n=t.find("[data-fieldhelpers-field-repeater]");n.length&&n.each(function(){i.initializeField(jQuery(this))})}return l(e,[{key:"initializeField",value:function(e){this.fields.push({$field:e,api:new f(e)})}}]),e}();t.default=c},function(e,t,i){"use strict";function n(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}function r(e,t){if(!e)throw new ReferenceError("this hasn't been initialised - super() hasn't been called");return!t||"object"!=typeof t&&"function"!=typeof t?e:t}function o(e,t){if("function"!=typeof t&&null!==t)throw new TypeError("Super expression must either be null or a function, not "+typeof t);e.prototype=Object.create(t&&t.prototype,{constructor:{value:e,enumerable:!1,writable:!0,configurable:!0}}),t&&(Object.setPrototypeOf?Object.setPrototypeOf(e,t):e.__proto__=t)}Object.defineProperty(t,"__esModule",{value:!0});var a=function(){function e(e,t){for(var i=0;i<t.length;i++){var n=t[i];n.enumerable=n.enumerable||!1,n.configurable=!0,"value"in n&&(n.writable=!0),Object.defineProperty(e,n.key,n)}}return function(t,i,n){return i&&e(t.prototype,i),n&&e(t,n),t}}(),l=function(e){return e&&e.__esModule?e:{default:e}}(i(0)),s=function(e){function t(e){n(this,t);var i=r(this,(t.__proto__||Object.getPrototypeOf(t)).call(this,e,"select"));return i.initField(),i}return o(t,l.default),a(t,[{key:"initField",value:function(){if(!this.options.select2Disabled){if(!jQuery.isFunction(jQuery.fn.select2))return void console.error('Field Helpers Error: Trying to initialize Select field but "select2" is not enqueued.');this.setupSelect2Options(),this.$field.select2(this.options.select2Options)}}},{key:"setupL10n",value:function(){var e=this;Object.keys(this.options.select2Options.language).length>0&&Object.keys(this.options.select2Options.language).map(function(t){var i=e.options.select2Options.language[t];e.options.select2Options.language[t]=function(e){return i}})}},{key:"setupSelect2Options",value:function(){var e=this;this.setupL10n();var t=["escapeMarkup","initSelection","matcher","query","sorter","templateResult","templateSelection","tokenizer"];Object.keys(this.options.select2Options).map(function(i){if(-1!==t.indexOf(i)){var n=e.options.select2Options[i];"function"==typeof window[n]&&(e.options.select2Options[i]=window[n])}}),this.options.optGroups&&this.options.optGroupSelectionPrefix&&void 0===this.options.select2Options.templateSelection&&(this.options.select2Options.templateSelection=function(e){return jQuery(e.element).closest("optgroup").attr("label").trim()+": "+e.text})}},{key:"fieldCleanup",value:function(){if(!this.options.select2Disabled){var e=this.$field.next(".select2");e.length&&e.remove(),this.$field.removeClass("select2-hidden-accessible").removeAttr("tablindex aria-hidden")}}},{key:"setDefault",value:function(){this.$field.find("option:selected").prop("selected",!1),this.$field.trigger("change")}}]),t}(),u=function(){function e(t){n(this,e);var i=this;this.fields=[];var r=t.find("[data-fieldhelpers-field-select]");r.length&&r.each(function(){i.initializeField(jQuery(this))})}return a(e,[{key:"initializeField",value:function(e){this.fields.push({$field:e,api:new s(e)})}}]),e}();t.default=u},function(e,t,i){"use strict";function n(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}function r(e,t){if(!e)throw new ReferenceError("this hasn't been initialised - super() hasn't been called");return!t||"object"!=typeof t&&"function"!=typeof t?e:t}function o(e,t){if("function"!=typeof t&&null!==t)throw new TypeError("Super expression must either be null or a function, not "+typeof t);e.prototype=Object.create(t&&t.prototype,{constructor:{value:e,enumerable:!1,writable:!0,configurable:!0}}),t&&(Object.setPrototypeOf?Object.setPrototypeOf(e,t):e.__proto__=t)}Object.defineProperty(t,"__esModule",{value:!0});var a=function(){function e(e,t){for(var i=0;i<t.length;i++){var n=t[i];n.enumerable=n.enumerable||!1,n.configurable=!0,"value"in n&&(n.writable=!0),Object.defineProperty(e,n.key,n)}}return function(t,i,n){return i&&e(t.prototype,i),n&&e(t,n),t}}(),l=function(e){return e&&e.__esModule?e:{default:e}}(i(0)),s=function(e){function t(e){n(this,t);var i=r(this,(t.__proto__||Object.getPrototypeOf(t)).call(this,e,"textarea"));return i.initField(),i}return o(t,l.default),a(t,[{key:"initField",value:function(){if(this.options.wysiwyg){if(!wp.editor)return void console.error('Field Helpers Error: Trying to initialize a WYSIWYG Text Area field but "wp_editor" is not enqueued.');var e=jQuery.extend(this.getDefaultEditorSettings(),this.options.wysiwygOptions);console.log(e),wp.editor.initialize(this.$field.attr("id"),e)}}},{key:"fieldCleanup",value:function(){if(this.options.wysiwyg){var e=this.$field.attr("id");window.tinymce.get(e)?wp.editor.remove(e):(this.$field.appendTo(this.$wrapper.find(".fieldhelpers-field-content")),this.$wrapper.find(".wp-editor-wrap").remove())}}},{key:"repeaterBeforeDeleteSelf",value:function(){this.fieldCleanup()}},{key:"repeaterOnDeleteItem",value:function(){var e=this;this.fieldCleanup(),this.repeaterSetID(),setTimeout(function(){e.initField()},1)}},{key:"repeaterOnSort",value:function(){var e=this;this.fieldCleanup(),this.repeaterSetID(),setTimeout(function(){e.initField()},1)}},{key:"getDefaultEditorSettings",value:function(){return jQuery.isFunction(wp.editor.getDefaultSettings)?wp.editor.getDefaultSettings():{}}}]),t}(),u=function(){function e(t){n(this,e);var i=this;this.fields=[];var r=t.find("[data-fieldhelpers-field-textarea]");r.length&&r.each(function(){i.initializeField(jQuery(this))})}return a(e,[{key:"initializeField",value:function(e){this.fields.push({$field:e,api:new s(e)})}}]),e}();t.default=u},function(e,t,i){"use strict";function n(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}function r(e,t){if(!e)throw new ReferenceError("this hasn't been initialised - super() hasn't been called");return!t||"object"!=typeof t&&"function"!=typeof t?e:t}function o(e,t){if("function"!=typeof t&&null!==t)throw new TypeError("Super expression must either be null or a function, not "+typeof t);e.prototype=Object.create(t&&t.prototype,{constructor:{value:e,enumerable:!1,writable:!0,configurable:!0}}),t&&(Object.setPrototypeOf?Object.setPrototypeOf(e,t):e.__proto__=t)}Object.defineProperty(t,"__esModule",{value:!0});var a=function(){function e(e,t){for(var i=0;i<t.length;i++){var n=t[i];n.enumerable=n.enumerable||!1,n.configurable=!0,"value"in n&&(n.writable=!0),Object.defineProperty(e,n.key,n)}}return function(t,i,n){return i&&e(t.prototype,i),n&&e(t,n),t}}(),l=function(e){return e&&e.__esModule?e:{default:e}}(i(0)),s=function(e){function t(e){n(this,t);var i=r(this,(t.__proto__||Object.getPrototypeOf(t)).call(this,e,"checkbox"));return i.initField(),i}return o(t,l.default),a(t,[{key:"initField",value:function(){this.$ui={checkboxes:this.$field.find('input[type="checkbox"]')},this.setupHandlers(),this.$field.find("input:checked").change()}},{key:"setupHandlers",value:function(){var e=this;this.$ui.checkboxes.change(function(){e.handleChange(jQuery(this))})}},{key:"handleChange",value:function(e){e.prop("checked")?this.setActive(e.closest(".fieldhelpers-field-checkbox-row")):this.setInactive(e.closest(".fieldhelpers-field-checkbox-row"))}},{key:"setActive",value:function(e){e.addClass("fieldhelpers-field-checkbox-row-active")}},{key:"setInactive",value:function(e){e.removeClass("fieldhelpers-field-checkbox-row-active")}},{key:"repeaterSetID",value:function(){var e=this.options.id,t=this.$field.find(".fieldhelpers-field-checkbox-row"),i=this.$field.closest("[data-repeater-item]").index();t.each(function(){var t=jQuery(this).find('input[type="checkbox"]'),n=t.next("label"),r=jQuery(this).index(),o=e+"_"+i+"_"+r;t.attr("id",o),n.attr("for",o)})}},{key:"setDefault",value:function(){this.options.default&&this.$field.find('[value="'+this.options.default+'"]').prop("checked",!0).change()}}]),t}(),u=function(){function e(t){n(this,e);var i=this;this.fields=[];var r=t.find("[data-fieldhelpers-field-checkbox]");r.length&&r.each(function(){i.initializeField(jQuery(this))})}return a(e,[{key:"initializeField",value:function(e){this.fields.push({$field:e,api:new s(e)})}}]),e}();t.default=u},function(e,t,i){"use strict";function n(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}function r(e,t){if(!e)throw new ReferenceError("this hasn't been initialised - super() hasn't been called");return!t||"object"!=typeof t&&"function"!=typeof t?e:t}function o(e,t){if("function"!=typeof t&&null!==t)throw new TypeError("Super expression must either be null or a function, not "+typeof t);e.prototype=Object.create(t&&t.prototype,{constructor:{value:e,enumerable:!1,writable:!0,configurable:!0}}),t&&(Object.setPrototypeOf?Object.setPrototypeOf(e,t):e.__proto__=t)}Object.defineProperty(t,"__esModule",{value:!0});var a=function(){function e(e,t){for(var i=0;i<t.length;i++){var n=t[i];n.enumerable=n.enumerable||!1,n.configurable=!0,"value"in n&&(n.writable=!0),Object.defineProperty(e,n.key,n)}}return function(t,i,n){return i&&e(t.prototype,i),n&&e(t,n),t}}(),l=function(e){return e&&e.__esModule?e:{default:e}}(i(0)),s=function(e){function t(e){n(this,t);var i=r(this,(t.__proto__||Object.getPrototypeOf(t)).call(this,e,"radio"));return i.initField(),i}return o(t,l.default),a(t,[{key:"initField",value:function(){this.$ui={radios:this.$field.find('input[type="radio"]')},this.setupHandlers(),this.$field.find("input:checked").change()}},{key:"setupHandlers",value:function(){var e=this;this.$ui.radios.change(function(){e.handleChange(jQuery(this))})}},{key:"handleChange",value:function(e){this.setInactive(this.$ui.radios.closest(".fieldhelpers-field-radio-row")),this.setActive(e.closest(".fieldhelpers-field-radio-row"))}},{key:"setActive",value:function(e){e.addClass("fieldhelpers-field-radio-row-active")}},{key:"setInactive",value:function(e){e.removeClass("fieldhelpers-field-radio-row-active")}},{key:"repeaterSetID",value:function(){var e=this.options.id,t=this.$field.find(".fieldhelpers-field-radio-row"),i=this.$field.closest("[data-repeater-item]").index();t.each(function(){var t=jQuery(this).find('input[type="radio"]'),n=t.next("label"),r=jQuery(this).index(),o=e+"_"+i+"_"+r;t.attr("id",o),n.attr("for",o)})}},{key:"setDefault",value:function(){this.options.default&&this.$field.find('[value="'+this.options.default+'"]').prop("checked",!0).change()}}]),t}(),u=function(){function e(t){n(this,e);var i=this;this.fields=[];var r=t.find("[data-fieldhelpers-field-radio]");r.length&&r.each(function(){i.initializeField(jQuery(this))})}return a(e,[{key:"initializeField",value:function(e){this.fields.push({$field:e,api:new s(e)})}}]),e}();t.default=u},function(e,t,i){"use strict";function n(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}function r(e,t){if(!e)throw new ReferenceError("this hasn't been initialised - super() hasn't been called");return!t||"object"!=typeof t&&"function"!=typeof t?e:t}function o(e,t){if("function"!=typeof t&&null!==t)throw new TypeError("Super expression must either be null or a function, not "+typeof t);e.prototype=Object.create(t&&t.prototype,{constructor:{value:e,enumerable:!1,writable:!0,configurable:!0}}),t&&(Object.setPrototypeOf?Object.setPrototypeOf(e,t):e.__proto__=t)}Object.defineProperty(t,"__esModule",{value:!0});var a=function(){function e(e,t){for(var i=0;i<t.length;i++){var n=t[i];n.enumerable=n.enumerable||!1,n.configurable=!0,"value"in n&&(n.writable=!0),Object.defineProperty(e,n.key,n)}}return function(t,i,n){return i&&e(t.prototype,i),n&&e(t,n),t}}(),l=function(e){return e&&e.__esModule?e:{default:e}}(i(0)),s=function(e){function t(e){n(this,t);var i=r(this,(t.__proto__||Object.getPrototypeOf(t)).call(this,e,"toggle"));return i.initField(),i}return o(t,l.default),a(t,[{key:"initField",value:function(){var e=this;this.getUI(),setTimeout(function(){e.$field.trigger("change",[e.$ui.input.val()])},1),this.setupHandlers()}},{key:"getUI",value:function(){this.$ui={slider:this.$field.find(".fieldhelpers-field-toggle-slider"),input:this.$field.find('input[type="hidden"]')}}},{key:"setupHandlers",value:function(){var e=this;this.$ui.slider.click(function(){e.handleClick()})}},{key:"isChecked",value:function(){return this.$field.hasClass("checked")}},{key:"handleClick",value:function(){this.isChecked()?(this.$ui.input.val(this.options.uncheckedValue),this.$field.removeClass("checked")):(this.$ui.input.val(this.options.checkedValue),this.$field.addClass("checked")),this.$field.trigger("change",[this.$ui.input.val()])}}]),t}(),u=function(){function e(t){n(this,e);var i=this;this.fields=[];var r=t.find("[data-fieldhelpers-field-toggle]");r.length&&r.each(function(){i.initializeField(jQuery(this))})}return a(e,[{key:"initializeField",value:function(e){this.fields.push({$field:e,api:new s(e)})}}]),e}();t.default=u}]);
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 2);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+/**
+ * Main field class.
+ *
+ * @since 1.4.0
+ */
+var Field = function () {
+
+    /**
+     * Class constructor.
+     *
+     * @since 1.4.0
+     *
+     * @param {jQuery} $field
+     * @param {string} type
+     */
+    function Field($field, type) {
+        _classCallCheck(this, Field);
+
+        this.$field = $field;
+        this.$wrapper = $field.closest('.fieldhelpers-field');
+        this.type = type;
+        this.name = this.$wrapper.attr('data-fieldhelpers-name');
+        this.instance = this.$wrapper.attr('data-fieldhelpers-instance');
+
+        this.getRepeater();
+
+        this.getOptions();
+
+        if (this.repeater) {
+
+            this.repeaterSupport();
+        }
+    }
+
+    /**
+     * Initializes the field.
+     *
+     * @since 1.4.0
+     */
+
+
+    _createClass(Field, [{
+        key: 'initField',
+        value: function initField() {}
+
+        /**
+         * Gets field options.
+         *
+         * @since 1.4.0
+         */
+
+    }, {
+        key: 'getOptions',
+        value: function getOptions() {
+
+            this.options = {};
+
+            if (typeof RBM_FieldHelpers[this.instance] === 'undefined') {
+
+                console.error('Field Helpers Error: Data for ' + this.instance + ' instance cannot be found.');
+                return;
+            }
+
+            if (this.repeater) {
+
+                if (typeof RBM_FieldHelpers[this.instance]['repeaterFields'][this.repeater] === 'undefined') {
+
+                    console.error('Field Helpers Error: Data for repeater ' + this.type + ' sub-fields cannot be found.');
+                    return;
+                }
+
+                if (typeof RBM_FieldHelpers[this.instance]['repeaterFields'][this.repeater][this.name] === 'undefined') {
+
+                    console.error('Field Helpers Error: Cannot find field options for repeater ' + this.type + ' sub-field with name: ' + this.name + '.');
+                    return;
+                }
+
+                this.options = RBM_FieldHelpers[this.instance]['repeaterFields'][this.repeater][this.name];
+            } else {
+
+                if (typeof RBM_FieldHelpers[this.instance][this.type] === 'undefined') {
+
+                    console.error('Field Helpers Error: Data for ' + this.type + ' fields cannot be found.');
+                    return;
+                }
+
+                if (typeof RBM_FieldHelpers[this.instance][this.type][this.name] === 'undefined') {
+
+                    console.error('Field Helpers Error: Cannot find field options for ' + this.type + ' field with name: ' + this.name + '.');
+                    return;
+                }
+
+                this.options = RBM_FieldHelpers[this.instance][this.type][this.name];
+            }
+        }
+
+        /**
+         * If field is in a Repeater, it will need support.
+         *
+         * @since 1.4.0
+         */
+
+    }, {
+        key: 'getRepeater',
+        value: function getRepeater() {
+
+            if (this.$field.closest('[data-fieldhelpers-field-repeater]').length) {
+
+                this.$repeater = this.$field.parent().closest('[data-fieldhelpers-field-repeater]');
+                this.repeater = this.$repeater.closest('.fieldhelpers-field-repeater').attr('data-fieldhelpers-name');
+            }
+        }
+
+        /**
+         * Runs some functions if inside a Repeater.
+         *
+         * @since 1.4.0
+         */
+
+    }, {
+        key: 'repeaterSupport',
+        value: function repeaterSupport() {
+            var _this = this;
+
+            // Triggers fields can utilize. Wrapped in anonymous to utilize self access.
+            this.$repeater.on('repeater-init', function () {
+                _this.repeaterOnInit();
+            });
+            this.$repeater.on('repeater-before-add-item', function () {
+                _this.repeaterBeforeAddItem();
+            });
+            this.$repeater.on('repeater-add-item', function () {
+                _this.repeaterOnAddItem();
+            });
+            this.$field.closest('[data-repeater-item]').on('repeater-before-delete-item', function () {
+                _this.repeaterBeforeDeleteSelf();
+            });
+            this.$repeater.on('repeater-before-delete-item', function () {
+                _this.repeaterBeforeDeleteItem();
+            });
+            this.$repeater.on('repeater-delete-item', function () {
+                _this.repeaterOnDeleteItem();
+            });
+            this.$repeater.find('.fieldhelpers-field-repeater-list').on('list-update', function () {
+                _this.repeaterOnSort();
+            });
+
+            this.repeaterSetID();
+            this.fieldCleanup();
+        }
+
+        /**
+         * Fires on Repeater init.
+         *
+         * @since 1.4.0
+         */
+
+    }, {
+        key: 'repeaterOnInit',
+        value: function repeaterOnInit() {}
+
+        /**
+         * Fires before Repeater add item.
+         *
+         * @since 1.4.0
+         */
+
+    }, {
+        key: 'repeaterBeforeAddItem',
+        value: function repeaterBeforeAddItem() {}
+
+        /**
+         * Fires on Repeater add item.
+         *
+         * @since 1.4.0
+         */
+
+    }, {
+        key: 'repeaterOnAddItem',
+        value: function repeaterOnAddItem() {}
+
+        /**
+         * Fires before Repeater delete item (localized to self).
+         *
+         * @since 1.4.0
+         */
+
+    }, {
+        key: 'repeaterBeforeDeleteSelf',
+        value: function repeaterBeforeDeleteSelf() {}
+
+        /**
+         * Fires before Repeater delete item.
+         *
+         * @since 1.4.0
+         */
+
+    }, {
+        key: 'repeaterBeforeDeleteItem',
+        value: function repeaterBeforeDeleteItem() {}
+
+        /**
+         * Fires on Repeater delete item.
+         *
+         * @since 1.4.0
+         */
+
+    }, {
+        key: 'repeaterOnDeleteItem',
+        value: function repeaterOnDeleteItem() {}
+
+        /**
+         * Fires on Repeat sort item.
+         *
+         * @since 1.4.0
+         */
+
+    }, {
+        key: 'repeaterOnSort',
+        value: function repeaterOnSort() {}
+
+        /**
+         * Sets the ID to be unique, based off the repeater item index.
+         *
+         * @since 1.4.0
+         */
+
+    }, {
+        key: 'repeaterSetID',
+        value: function repeaterSetID() {
+
+            var index = this.$field.closest('[data-repeater-item]').index();
+            var newID = this.options.id + '_' + index;
+
+            this.$field.attr('id', newID);
+        }
+
+        /**
+         * Cleans up after a repeater add/init.
+         *
+         * @since 1.4.0
+         */
+
+    }, {
+        key: 'fieldCleanup',
+        value: function fieldCleanup() {}
+
+        /**
+         * Sets the field to default. Override in child class if need different method.
+         *
+         * @since 1.4.0
+         */
+
+    }, {
+        key: 'setDefault',
+        value: function setDefault() {
+
+            if (this.options.default) {
+
+                this.$field.val(this.options.default).change();
+            }
+        }
+    }]);
+
+    return Field;
+}();
+
+exports.default = Field;
+
+/***/ }),
+/* 1 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+
+var _fieldNumber = __webpack_require__(4);
+
+var _fieldNumber2 = _interopRequireDefault(_fieldNumber);
+
+var _fieldColorpicker = __webpack_require__(5);
+
+var _fieldColorpicker2 = _interopRequireDefault(_fieldColorpicker);
+
+var _fieldDatepicker = __webpack_require__(6);
+
+var _fieldDatepicker2 = _interopRequireDefault(_fieldDatepicker);
+
+var _fieldTimepicker = __webpack_require__(7);
+
+var _fieldTimepicker2 = _interopRequireDefault(_fieldTimepicker);
+
+var _fieldDatetimepicker = __webpack_require__(8);
+
+var _fieldDatetimepicker2 = _interopRequireDefault(_fieldDatetimepicker);
+
+var _fieldTable = __webpack_require__(9);
+
+var _fieldTable2 = _interopRequireDefault(_fieldTable);
+
+var _fieldMedia = __webpack_require__(10);
+
+var _fieldMedia2 = _interopRequireDefault(_fieldMedia);
+
+var _fieldList = __webpack_require__(11);
+
+var _fieldList2 = _interopRequireDefault(_fieldList);
+
+var _fieldRepeater = __webpack_require__(12);
+
+var _fieldRepeater2 = _interopRequireDefault(_fieldRepeater);
+
+var _fieldSelect = __webpack_require__(13);
+
+var _fieldSelect2 = _interopRequireDefault(_fieldSelect);
+
+var _fieldTextarea = __webpack_require__(14);
+
+var _fieldTextarea2 = _interopRequireDefault(_fieldTextarea);
+
+var _fieldCheckbox = __webpack_require__(15);
+
+var _fieldCheckbox2 = _interopRequireDefault(_fieldCheckbox);
+
+var _fieldRadio = __webpack_require__(16);
+
+var _fieldRadio2 = _interopRequireDefault(_fieldRadio);
+
+var _fieldToggle = __webpack_require__(17);
+
+var _fieldToggle2 = _interopRequireDefault(_fieldToggle);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+/**
+ * Handles all field initializations.
+ *
+ * @since 1.4.0
+ */
+var FieldsInitialize =
+
+/**
+ * Class constructor.
+ *
+ * @since 1.4.0
+ *
+ * @param {jQuery} $root Root element to initialize fields inside.
+ */
+function FieldsInitialize($root) {
+    _classCallCheck(this, FieldsInitialize);
+
+    this.fields = {
+        checkbox: new _fieldCheckbox2.default($root),
+        toggle: new _fieldToggle2.default($root),
+        radio: new _fieldRadio2.default($root),
+        select: new _fieldSelect2.default($root),
+        textarea: new _fieldTextarea2.default($root),
+        number: new _fieldNumber2.default($root),
+        colorpicker: new _fieldColorpicker2.default($root),
+        datepicker: new _fieldDatepicker2.default($root),
+        timepicker: new _fieldTimepicker2.default($root),
+        datetimepicker: new _fieldDatetimepicker2.default($root),
+        table: new _fieldTable2.default($root),
+        media: new _fieldMedia2.default($root),
+        list: new _fieldList2.default($root),
+        repeater: new _fieldRepeater2.default($root)
+    };
+};
+
+exports.default = FieldsInitialize;
+
+/***/ }),
+/* 2 */
+/***/ (function(module, exports, __webpack_require__) {
+
+module.exports = __webpack_require__(3);
+
+
+/***/ }),
+/* 3 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var _fieldsInit = __webpack_require__(1);
+
+var _fieldsInit2 = _interopRequireDefault(_fieldsInit);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+// Initialize app on jQuery Ready.
+jQuery(function () {
+
+    var Fields = new _fieldsInit2.default(jQuery(document));
+});
+
+/***/ }),
+/* 4 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _field = __webpack_require__(0);
+
+var _field2 = _interopRequireDefault(_field);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+/**
+ * Number Field functionality.
+ *
+ * @since 1.4.0
+ */
+var FieldNumber = function (_Field) {
+    _inherits(FieldNumber, _Field);
+
+    /**
+     * Class constructor.
+     *
+     * @since 1.4.0
+     */
+    function FieldNumber($field) {
+        _classCallCheck(this, FieldNumber);
+
+        var _this = _possibleConstructorReturn(this, (FieldNumber.__proto__ || Object.getPrototypeOf(FieldNumber)).call(this, $field, 'number'));
+
+        _this.initField();
+        return _this;
+    }
+
+    /**
+     * Initializes the Number field.
+     *
+     * @since 1.4.0
+     */
+
+
+    _createClass(FieldNumber, [{
+        key: 'initField',
+        value: function initField() {
+
+            this.$ui = {
+                container: this.$field,
+                input: this.$field.find('.fieldhelpers-field-input'),
+                increase: this.$field.find('[data-number-increase]'),
+                decrease: this.$field.find('[data-number-decrease]')
+            };
+
+            this.intervals = {
+                increase: {
+                    normal: parseInt(this.options.increaseInterval),
+                    alt: parseInt(this.options.altIncreaseInterval)
+                },
+                decrease: {
+                    normal: parseInt(this.options.decreaseInterval),
+                    alt: parseInt(this.options.altDecreaseInterval)
+                }
+            };
+
+            var constrainMax = this.options.max;
+            var constrainMin = this.options.min;
+
+            this.constraints = {
+                max: constrainMax !== 'none' ? parseInt(constrainMax) : false,
+                min: constrainMin !== 'none' ? parseInt(constrainMin) : false
+            };
+
+            this.shiftKeyUtility();
+            this.setupHandlers();
+
+            var initialValue = this.$ui.input.val();
+            this.value = !initialValue ? 0 : parseInt(initialValue);
+
+            // Initializes the field
+            this.validateInput();
+        }
+
+        /**
+         * Helps determine shift key press status.
+         *
+         * @since 1.4.0
+         */
+
+    }, {
+        key: 'shiftKeyUtility',
+        value: function shiftKeyUtility() {
+            var _this2 = this;
+
+            this.shiftKeyDown = false;
+
+            jQuery(document).on('keydown', function (e) {
+
+                if (e.which === 16) {
+
+                    _this2.shiftKeyDown = true;
+                }
+            });
+
+            jQuery(document).on('keyup', function (e) {
+
+                if (e.which === 16) {
+
+                    _this2.shiftKeyDown = false;
+                }
+            });
+        }
+
+        /**
+         * Sets up the class handlers.
+         *
+         * @since 1.4.0
+         */
+
+    }, {
+        key: 'setupHandlers',
+        value: function setupHandlers() {
+            var _this3 = this;
+
+            this.$ui.increase.click(function (e) {
+
+                _this3.increaseNumber(e);
+            });
+
+            this.$ui.decrease.click(function (e) {
+
+                _this3.decreaseNumber(e);
+            });
+
+            this.$ui.input.change(function (e) {
+
+                _this3.inputExternalChange(e);
+            });
+        }
+
+        /**
+         * Increases the input number.
+         *
+         * @since 1.4.0
+         */
+
+    }, {
+        key: 'increaseNumber',
+        value: function increaseNumber() {
+
+            var amount = this.shiftKeyDown ? this.intervals.increase.alt : this.intervals.increase.normal;
+            var newNumber = this.value + amount;
+
+            this.$ui.input.val(newNumber);
+            this.$ui.input.trigger('change');
+        }
+
+        /**
+         * Decreases the input number.
+         *
+         * @since 1.4.0
+         */
+
+    }, {
+        key: 'decreaseNumber',
+        value: function decreaseNumber() {
+
+            var amount = this.shiftKeyDown ? this.intervals.decrease.alt : this.intervals.decrease.normal;
+            var newNumber = this.value - amount;
+
+            this.$ui.input.val(newNumber);
+            this.$ui.input.trigger('change');
+        }
+
+        /**
+         * Fires on the input change. Typically from user typing or other scripts modifying.
+         *
+         * @since 1.4.0
+         */
+
+    }, {
+        key: 'inputExternalChange',
+        value: function inputExternalChange() {
+
+            this.validateInput();
+        }
+
+        /**
+         * Runs number through constrains.
+         *
+         * @param {int} number
+         *
+         * @return {Object}
+         */
+
+    }, {
+        key: 'constrainNumber',
+        value: function constrainNumber(number) {
+
+            var status = 'unmodified';
+
+            if (this.constraints.max !== false && number > this.constraints.max) {
+
+                status = 'max';
+                number = this.constraints.max;
+            } else if (this.constraints.min !== false && number < this.constraints.min) {
+
+                status = 'min';
+                number = this.constraints.min;
+            }
+
+            return {
+                status: status,
+                number: number
+            };
+        }
+
+        /**
+         * Runs input value through constraints to ensure it is accurate.
+         *
+         * @since 1.4.0
+         */
+
+    }, {
+        key: 'validateInput',
+        value: function validateInput() {
+
+            var currentValue = this.$ui.input.val();
+
+            // Constrain to numbers
+            var matches = currentValue.match(/^-?[0-9]\d*(\.\d+)?$/);
+            currentValue = matches && parseInt(matches[0]) || 0;
+
+            var constraints = this.constrainNumber(currentValue);
+
+            switch (constraints.status) {
+
+                case 'max':
+
+                    this.toggleDecreaseDisabledUI(true);
+                    this.toggleIncreaseDisabledUI(false);
+                    break;
+
+                case 'min':
+
+                    this.toggleIncreaseDisabledUI(true);
+                    this.toggleDecreaseDisabledUI(false);
+                    break;
+
+                default:
+
+                    this.toggleIncreaseDisabledUI(true);
+                    this.toggleDecreaseDisabledUI(true);
+
+            }
+
+            this.value = constraints.number;
+            this.$ui.input.val(this.value);
+
+            if (currentValue !== this.value) {
+
+                this.$ui.input.trigger('change');
+            }
+        }
+
+        /**
+         * Disables/Enables the increase button.
+         *
+         * @since 1.4.0
+         *
+         * @param {bool} enable True to set to enabled, false to set to disabled
+         */
+
+    }, {
+        key: 'toggleIncreaseDisabledUI',
+        value: function toggleIncreaseDisabledUI(enable) {
+
+            this.$ui.increase.prop('disabled', !enable);
+        }
+
+        /**
+         * Disables/Enables the decrease button.
+         *
+         * @since 1.4.0
+         *
+         * @param {bool} enable True to set to enabled, false to set to disabled
+         */
+
+    }, {
+        key: 'toggleDecreaseDisabledUI',
+        value: function toggleDecreaseDisabledUI(enable) {
+
+            this.$ui.decrease.prop('disabled', !enable);
+        }
+    }]);
+
+    return FieldNumber;
+}(_field2.default);
+
+/**
+ * Finds and initializes all Number fields.
+ *
+ * @since 1.4.0
+ */
+
+
+var FieldNumberInitialize = function () {
+
+    /**
+     * Class constructor.
+     *
+     * @since 1.4.0
+     *
+     * @param {jQuery} $root Root element to initialize fields inside.
+     */
+    function FieldNumberInitialize($root) {
+        _classCallCheck(this, FieldNumberInitialize);
+
+        var api = this;
+
+        this.fields = [];
+
+        var $fields = $root.find('[data-fieldhelpers-field-number]');
+
+        if ($fields.length) {
+
+            $fields.each(function () {
+
+                api.initializeField(jQuery(this));
+            });
+        }
+    }
+
+    /**
+     * Initializes the field.
+     *
+     * @since 1.4.0
+     *
+     * @param {jQuery} $field
+     */
+
+
+    _createClass(FieldNumberInitialize, [{
+        key: 'initializeField',
+        value: function initializeField($field) {
+
+            this.fields.push({
+                $field: $field,
+                api: new FieldNumber($field)
+            });
+        }
+    }]);
+
+    return FieldNumberInitialize;
+}();
+
+exports.default = FieldNumberInitialize;
+
+/***/ }),
+/* 5 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _field = __webpack_require__(0);
+
+var _field2 = _interopRequireDefault(_field);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+/**
+ * Color Picker Field functionality.
+ *
+ * @since 1.4.0
+ */
+var FieldColorPicker = function (_Field) {
+    _inherits(FieldColorPicker, _Field);
+
+    /**
+     * Class constructor.
+     *
+     * @since 1.4.0
+     */
+    function FieldColorPicker($field) {
+        _classCallCheck(this, FieldColorPicker);
+
+        var _this = _possibleConstructorReturn(this, (FieldColorPicker.__proto__ || Object.getPrototypeOf(FieldColorPicker)).call(this, $field, 'colorpicker'));
+
+        _this.initializeColorpicker();
+        return _this;
+    }
+
+    /**
+     * Initializes the Color Picker.
+     *
+     * @since 1.4.0
+     */
+
+
+    _createClass(FieldColorPicker, [{
+        key: 'initializeColorpicker',
+        value: function initializeColorpicker() {
+
+            this.$field.wpColorPicker();
+        }
+
+        /**
+         * Cleans up after a repeater add/init.
+         *
+         * @since 1.4.0
+         */
+
+    }, {
+        key: 'fieldCleanup',
+        value: function fieldCleanup() {
+
+            this.$wrapper.find('[data-fieldhelpers-field-colorpicker]').appendTo(this.$wrapper.find('.fieldhelpers-field-content'));
+
+            this.$wrapper.find('.wp-picker-container').remove();
+        }
+    }]);
+
+    return FieldColorPicker;
+}(_field2.default);
+
+/**
+ * Finds and initializes all Color Picker fields.
+ *
+ * @since 1.4.0
+ */
+
+
+var FieldColorPickerInitialize = function () {
+
+    /**
+     * Class constructor.
+     *
+     * @since 1.4.0
+     *
+     * @param {jQuery} $root Root element to initialize fields inside.
+     */
+    function FieldColorPickerInitialize($root) {
+        _classCallCheck(this, FieldColorPickerInitialize);
+
+        var api = this;
+
+        this.fields = [];
+
+        var $fields = $root.find('[data-fieldhelpers-field-colorpicker]');
+
+        if ($fields.length) {
+
+            if (!jQuery.isFunction(jQuery.fn.wpColorPicker)) {
+
+                console.error('Field Helpers Error: Trying to initialize Color Picker field but "wp-color-picker" is ' + 'not enqueued.');
+                return;
+            }
+
+            $fields.each(function () {
+
+                api.initializeField(jQuery(this));
+            });
+        }
+    }
+
+    /**
+     * Initializes the field.
+     *
+     * @since 1.4.0
+     *
+     * @param {jQuery} $field
+     */
+
+
+    _createClass(FieldColorPickerInitialize, [{
+        key: 'initializeField',
+        value: function initializeField($field) {
+
+            this.fields.push({
+                $field: $field,
+                api: new FieldColorPicker($field)
+            });
+        }
+    }]);
+
+    return FieldColorPickerInitialize;
+}();
+
+exports.default = FieldColorPickerInitialize;
+
+/***/ }),
+/* 6 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _field = __webpack_require__(0);
+
+var _field2 = _interopRequireDefault(_field);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+/**
+ * Date Picker Field functionality.
+ *
+ * Also includes Date/Time Picker and Time Picker.
+ *
+ * @since 1.4.0
+ */
+var FieldDatePicker = function (_Field) {
+    _inherits(FieldDatePicker, _Field);
+
+    /**
+     * Class constructor.
+     *
+     * @since 1.4.0
+     */
+    function FieldDatePicker($field) {
+        _classCallCheck(this, FieldDatePicker);
+
+        var _this = _possibleConstructorReturn(this, (FieldDatePicker.__proto__ || Object.getPrototypeOf(FieldDatePicker)).call(this, $field, 'datepicker'));
+
+        _this.initField();
+        return _this;
+    }
+
+    /**
+     * Initializes the Date Picker.
+     *
+     * @since 1.4.0
+     */
+
+
+    _createClass(FieldDatePicker, [{
+        key: 'initField',
+        value: function initField() {
+            var _this2 = this;
+
+            this.$hiddenField = this.$field.next('input[type="hidden"]');
+
+            var option_functions = ['beforeShow', 'beforeShowDay', 'calculateWeek', 'onChangeMonthYear', 'onClose', 'onSelect'];
+
+            // Function support
+            jQuery.each(this.options.datepickerOptions, function (name, value) {
+
+                if (option_functions.indexOf(name) !== -1 && !jQuery.isFunction(_this2.options.datepickerOptions[name]) && jQuery.isFunction(window[value])) {
+
+                    _this2.options.datepickerOptions[name] = window[value];
+                }
+            });
+
+            this.options.datepickerOptions.altField = this.$hiddenField;
+
+            this.$field.datepicker(this.options.datepickerOptions);
+        }
+
+        /**
+         * Cleans up after a repeater add/init.
+         *
+         * @since 1.4.0
+         */
+
+    }, {
+        key: 'fieldCleanup',
+        value: function fieldCleanup() {
+
+            this.$field.removeClass('hasDatepicker').removeAttr('id');
+        }
+    }]);
+
+    return FieldDatePicker;
+}(_field2.default);
+
+/**
+ * Finds and initializes all Date Picker fields.
+ *
+ * @since 1.4.0
+ */
+
+
+var FieldDatePickerInitialize = function () {
+
+    /**
+     * Class constructor.
+     *
+     * @since 1.4.0
+     *
+     * @param {jQuery} $root Root element to initialize fields inside.
+     */
+    function FieldDatePickerInitialize($root) {
+        _classCallCheck(this, FieldDatePickerInitialize);
+
+        var api = this;
+
+        this.fields = [];
+
+        var $fields = $root.find('[data-fieldhelpers-field-datepicker]');
+
+        if ($fields.length) {
+
+            if (!jQuery.isFunction(jQuery.fn.datepicker)) {
+
+                console.error('Field Helpers Error: Trying to initialize Date Picker field but "jquery-ui-datepicker" ' + 'is not enqueued.');
+                return;
+            }
+
+            $fields.each(function () {
+
+                api.initializeField(jQuery(this));
+            });
+        }
+    }
+
+    /**
+     * Initializes the field.
+     *
+     * @since 1.4.0
+     *
+     * @param {jQuery} $field
+     */
+
+
+    _createClass(FieldDatePickerInitialize, [{
+        key: 'initializeField',
+        value: function initializeField($field) {
+
+            this.fields.push({
+                $field: $field,
+                api: new FieldDatePicker($field)
+            });
+        }
+    }]);
+
+    return FieldDatePickerInitialize;
+}();
+
+exports.default = FieldDatePickerInitialize;
+
+/***/ }),
+/* 7 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _field = __webpack_require__(0);
+
+var _field2 = _interopRequireDefault(_field);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+/**
+ * Time Picker Field functionality.
+ *
+ * Also includes Date/Time Picker and Time Picker.
+ *
+ * @since 1.4.0
+ */
+var FieldTimePicker = function (_Field) {
+    _inherits(FieldTimePicker, _Field);
+
+    /**
+     * Class constructor.
+     *
+     * @since 1.4.0
+     */
+    function FieldTimePicker($field) {
+        _classCallCheck(this, FieldTimePicker);
+
+        var _this = _possibleConstructorReturn(this, (FieldTimePicker.__proto__ || Object.getPrototypeOf(FieldTimePicker)).call(this, $field, 'timepicker'));
+
+        _this.initField();
+        return _this;
+    }
+
+    /**
+     * Initializes the Time Picker.
+     *
+     * @since 1.4.0
+     */
+
+
+    _createClass(FieldTimePicker, [{
+        key: 'initField',
+        value: function initField() {
+            var _this2 = this;
+
+            this.$hiddenField = this.$field.next('input[type="hidden"]');
+
+            var option_functions = ['beforeShow', 'beforeShowDay', 'calculateWeek', 'onChangeMonthYear', 'onClose', 'onSelect'];
+            var options = {};
+
+            if (RBM_FieldHelpers['datepicker_args_' + name]) {
+
+                options = RBM_FieldHelpers['datepicker_args_' + name];
+            }
+
+            // Function support
+            jQuery.each(this.options.timepickerOptions, function (name, value) {
+
+                if (option_functions.indexOf(name) !== -1 && !jQuery.isFunction(_this2.options.timepickerOptions[name]) && jQuery.isFunction(window[value])) {
+
+                    _this2.options.timepickerOptions[name] = window[value];
+                }
+            });
+
+            options.altField = this.$hiddenField;
+
+            this.$field.timepicker(this.options.timepickerOptions);
+        }
+
+        /**
+         * Cleans up after a repeater add/init.
+         *
+         * @since 1.4.0
+         */
+
+    }, {
+        key: 'fieldCleanup',
+        value: function fieldCleanup() {
+
+            this.$field.removeClass('hasDatepicker').removeAttr('id');
+        }
+    }]);
+
+    return FieldTimePicker;
+}(_field2.default);
+
+/**
+ * Finds and initializes all Time Picker fields.
+ *
+ * @since 1.4.0
+ */
+
+
+var FieldTimePickerInitialize = function () {
+
+    /**
+     * Class constructor.
+     *
+     * @since 1.4.0
+     *
+     * @param {jQuery} $root Root element to initialize fields inside.
+     */
+    function FieldTimePickerInitialize($root) {
+        _classCallCheck(this, FieldTimePickerInitialize);
+
+        var api = this;
+
+        this.fields = [];
+
+        var $fields = $root.find('[data-fieldhelpers-field-timepicker]');
+
+        if ($fields.length) {
+
+            if (!jQuery.isFunction(jQuery.fn.timepicker)) {
+
+                console.error('Field Helpers Error: Trying to initialize Time Picker field but ' + '"jquery-ui-datetimepicker" is not enqueued.');
+                return;
+            }
+
+            $fields.each(function () {
+
+                api.initializeField(jQuery(this));
+            });
+        }
+    }
+
+    /**
+     * Initializes the field.
+     *
+     * @since 1.4.0
+     *
+     * @param {jQuery} $field
+     */
+
+
+    _createClass(FieldTimePickerInitialize, [{
+        key: 'initializeField',
+        value: function initializeField($field) {
+
+            this.fields.push({
+                $field: $field,
+                api: new FieldTimePicker($field)
+            });
+        }
+    }]);
+
+    return FieldTimePickerInitialize;
+}();
+
+exports.default = FieldTimePickerInitialize;
+
+/***/ }),
+/* 8 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _field = __webpack_require__(0);
+
+var _field2 = _interopRequireDefault(_field);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+/**
+ * Date Time Picker Field functionality.
+ *
+ * Also includes Date/Time Picker and Time Picker.
+ *
+ * @since 1.4.0
+ */
+var FieldDateTimePicker = function (_Field) {
+    _inherits(FieldDateTimePicker, _Field);
+
+    /**
+     * Class constructor.
+     *
+     * @since 1.4.0
+     */
+    function FieldDateTimePicker($field) {
+        _classCallCheck(this, FieldDateTimePicker);
+
+        var _this = _possibleConstructorReturn(this, (FieldDateTimePicker.__proto__ || Object.getPrototypeOf(FieldDateTimePicker)).call(this, $field, 'datetimepicker'));
+
+        _this.initField();
+        return _this;
+    }
+
+    /**
+     * Initializes the Date Time Picker.
+     *
+     * @since 1.4.0
+     */
+
+
+    _createClass(FieldDateTimePicker, [{
+        key: 'initField',
+        value: function initField() {
+            var _this2 = this;
+
+            this.$hiddenField = this.$field.next('input[type="hidden"]');
+
+            var option_functions = ['beforeShow', 'beforeShowDay', 'calculateWeek', 'onChangeMonthYear', 'onClose', 'onSelect'];
+
+            // Function support
+            jQuery.each(this.options.datetimepickerOptions, function (name, value) {
+
+                if (option_functions.indexOf(name) !== -1 && !jQuery.isFunction(_this2.options.datetimepickerOptions[name]) && jQuery.isFunction(window[value])) {
+
+                    _this2.options.datetimepickerOptions[name] = window[value];
+                }
+            });
+
+            this.options.datetimepickerOptions.altField = this.$hiddenField;
+
+            this.$field.datetimepicker(this.options.datetimepickerOptions);
+        }
+
+        /**
+         * Cleans up after a repeater add/init.
+         *
+         * @since 1.4.0
+         */
+
+    }, {
+        key: 'fieldCleanup',
+        value: function fieldCleanup() {
+
+            this.$field.removeClass('hasDatepicker').removeAttr('id');
+        }
+    }]);
+
+    return FieldDateTimePicker;
+}(_field2.default);
+
+/**
+ * Finds and initializes all Date Time Picker fields.
+ *
+ * @since 1.4.0
+ */
+
+
+var FieldDateTimePickerInitialize = function () {
+
+    /**
+     * Class constructor.
+     *
+     * @since 1.4.0
+     *
+     * @param {jQuery} $root Root element to initialize fields inside.
+     */
+    function FieldDateTimePickerInitialize($root) {
+        _classCallCheck(this, FieldDateTimePickerInitialize);
+
+        var api = this;
+
+        this.fields = [];
+
+        var $fields = $root.find('[data-fieldhelpers-field-datetimepicker]');
+
+        if ($fields.length) {
+
+            if (!jQuery.isFunction(jQuery.fn.datetimepicker)) {
+
+                console.error('Field Helpers Error: Trying to initialize Date Time Picker field but ' + '"rbm-fh-jquery-ui-datetimepicker" is not enqueued.');
+                return;
+            }
+
+            $fields.each(function () {
+
+                api.initializeField(jQuery(this));
+            });
+        }
+    }
+
+    /**
+     * Initializes the field.
+     *
+     * @since 1.4.0
+     *
+     * @param {jQuery} $field
+     */
+
+
+    _createClass(FieldDateTimePickerInitialize, [{
+        key: 'initializeField',
+        value: function initializeField($field) {
+
+            this.fields.push({
+                $field: $field,
+                api: new FieldDateTimePicker($field)
+            });
+        }
+    }]);
+
+    return FieldDateTimePickerInitialize;
+}();
+
+exports.default = FieldDateTimePickerInitialize;
+
+/***/ }),
+/* 9 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _field = __webpack_require__(0);
+
+var _field2 = _interopRequireDefault(_field);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+/**
+ * Table Field functionality.
+ *
+ * @since 1.4.0
+ */
+var FieldTable = function (_Field) {
+    _inherits(FieldTable, _Field);
+
+    /**
+     * Class constructor.
+     *
+     * @since 1.4.0
+     */
+    function FieldTable($field) {
+        _classCallCheck(this, FieldTable);
+
+        var _this = _possibleConstructorReturn(this, (FieldTable.__proto__ || Object.getPrototypeOf(FieldTable)).call(this, $field, 'table'));
+
+        _this.initField();
+        return _this;
+    }
+
+    /**
+     * Initializes the Table field.
+     *
+     * @since 1.4.0
+     */
+
+
+    _createClass(FieldTable, [{
+        key: 'initField',
+        value: function initField() {
+
+            this.$ui = {
+                actions: this.$field.find('.fieldhelpers-field-table-actions'),
+                loading: this.$field.find('.fieldhelpers-field-table-loading'),
+                table: this.$field.find('table'),
+                thead: this.$field.find('thead'),
+                tbody: this.$field.find('tbody'),
+                addRow: this.$field.find('[data-table-create-row]'),
+                addColumn: this.$field.find('[data-table-create-column]')
+            };
+
+            this.l10n = RBM_FieldHelpers.l10n['field_table'] || {};
+
+            this.name = this.$field.attr('data-table-name');
+
+            var data = JSON.parse(this.$ui.table.attr('data-table-data'));
+
+            this.data = {};
+            this.data.head = data.head || [];
+            this.data.body = data.body || [];
+
+            this.setupHandlers();
+
+            // Initial build
+            this.buildTable();
+
+            // Show initially
+            this.$ui.table.show();
+            this.$ui.actions.show();
+            this.$ui.loading.hide();
+        }
+
+        /**
+         * Sets up the class handlers.
+         *
+         * @since 1.4.0
+         */
+
+    }, {
+        key: 'setupHandlers',
+        value: function setupHandlers() {
+            var _this2 = this;
+
+            var api = this;
+
+            this.$ui.addRow.click(function (e) {
+
+                e.preventDefault();
+                _this2.addRow();
+            });
+
+            this.$ui.addColumn.click(function (e) {
+
+                e.preventDefault();
+                _this2.addColumn();
+            });
+
+            this.$ui.table.on('click', '[data-delete-row]', function (e) {
+
+                var index = jQuery(this).closest('tr').index();
+
+                api.deleteRow(index);
+            });
+
+            this.$ui.table.on('click', '[data-delete-column]', function (e) {
+
+                var index = jQuery(this).closest('td').index();
+
+                api.deleteColumn(index);
+            });
+
+            this.$ui.table.on('change', 'input[type="text"]', function (e) {
+
+                _this2.updateTableData();
+            });
+        }
+
+        /**
+         * Gathers all data from the table.
+         */
+
+    }, {
+        key: 'updateTableData',
+        value: function updateTableData() {
+
+            var api = this;
+
+            // Head
+            var $headCells = this.$ui.table.find('thead th');
+            var dataHead = [];
+            var currentCell = 0;
+
+            $headCells.each(function () {
+
+                var $input = jQuery(this).find('input[name="' + api.name + '[head][' + currentCell + ']"]');
+
+                if (!$input.length) {
+
+                    console.error('Field Helpers Error: Table head data corrupted.');
+                    return false;
+                }
+
+                dataHead.push($input.val());
+
+                currentCell++;
+            });
+
+            this.data.head = dataHead;
+
+            // Body
+            var $bodyRows = this.$ui.table.find('tbody tr');
+            var dataBody = [];
+            var currentRow = 0;
+
+            $bodyRows.each(function () {
+
+                // Skip delete row
+                if (jQuery(this).hasClass('fieldhelpers-field-table-delete-columns')) {
+
+                    return true;
+                }
+
+                var rowData = [];
+                var $cells = jQuery(this).find('td');
+                var currentCell = 0;
+
+                $cells.each(function () {
+
+                    // Skip delete cell
+                    if (jQuery(this).hasClass('fieldhelpers-field-table-delete-row')) {
+
+                        return true;
+                    }
+
+                    var $input = jQuery(this).find('input[name="' + api.name + '[body][' + currentRow + '][' + currentCell + ']"]');
+
+                    if (!$input.length) {
+
+                        console.error('Field Helpers Error: Table body data corrupted.');
+                        return false;
+                    }
+
+                    rowData.push($input.val());
+
+                    currentCell++;
+                });
+
+                dataBody.push(rowData);
+
+                currentRow++;
+            });
+
+            this.data.body = dataBody;
+        }
+
+        /**
+         * Adds a row to the table.
+         *
+         * @since 1.4.0
+         */
+
+    }, {
+        key: 'addRow',
+        value: function addRow() {
+
+            if (!this.data.head.length) {
+
+                this.data.head.push('');
+            }
+
+            if (!this.data.body.length) {
+
+                // Push 1 empty row with 1 empty cell
+                this.data.body.push(['']);
+            } else {
+
+                var columns = this.data.body[0].length;
+                var row = [];
+
+                for (var i = 0; i < columns; i++) {
+                    row.push('');
+                }
+
+                this.data.body.push(row);
+            }
+
+            this.buildTable();
+        }
+
+        /**
+         * Adds a column to the table.
+         *
+         * @since 1.4.0
+         */
+
+    }, {
+        key: 'addColumn',
+        value: function addColumn() {
+
+            if (!this.data.body.length) {
+
+                // Push 1 empty row with 1 empty cell
+                this.data.head.push(['']);
+                this.data.body.push(['']);
+            } else {
+
+                this.data.head.push('');
+
+                this.data.body.map(function (row) {
+                    row.push('');
+                });
+            }
+
+            this.buildTable();
+        }
+
+        /**
+         * Deletes a row from the table.
+         *
+         * @since 1.4.0
+         *
+         * @param {int} index Index of row to delete.
+         */
+
+    }, {
+        key: 'deleteRow',
+        value: function deleteRow(index) {
+
+            // Decrease to compensate for "delete row" at top
+            index--;
+
+            if (this.data.body.length === 1) {
+
+                this.data.head = [];
+                this.data.body = [];
+            } else {
+
+                this.data.body.splice(index, 1);
+            }
+
+            this.buildTable();
+        }
+
+        /**
+         * Deletes a column from the table.
+         *
+         * @since 1.4.0
+         *
+         * @param {int} index Index of column to delete.
+         */
+
+    }, {
+        key: 'deleteColumn',
+        value: function deleteColumn(index) {
+
+            if (this.data.body[0].length === 1) {
+
+                this.data.head = [];
+                this.data.body = [];
+            } else {
+
+                this.data.head.splice(index, 1);
+
+                this.data.body.map(function (row) {
+                    return row.splice(index, 1);
+                });
+            }
+
+            this.buildTable();
+        }
+
+        /**
+         * Builds the table based on the table data.
+         *
+         * @since 1.4.0
+         */
+
+    }, {
+        key: 'buildTable',
+        value: function buildTable() {
+            var _this3 = this;
+
+            this.$ui.thead.html('');
+            this.$ui.tbody.html('');
+
+            if (this.data.head.length) {
+
+                var $row = jQuery('<tr />');
+
+                this.data.head.map(function (cell, cell_i) {
+
+                    var $cell = jQuery('<th />');
+
+                    $cell.append('<input type="text" name="' + _this3.name + '[head][' + cell_i + ']" />');
+                    $cell.find('input[type="text"]').val(cell);
+
+                    $row.append($cell);
+                });
+
+                this.$ui.thead.append($row);
+            }
+
+            if (this.data.body.length) {
+
+                var $deleteRow = jQuery('<tr class="fieldhelpers-field-table-delete-columns"></tr>');
+
+                for (var i = 0; i < this.data.body[0].length; i++) {
+
+                    $deleteRow.append('<td>' + ('<button type="button" data-delete-column aria-label="' + this.l10n['delete_column'] + '">') + '<span class="dashicons dashicons-no" />' + '</button>' + '</td>');
+                }
+
+                this.$ui.tbody.append($deleteRow);
+
+                this.data.body.map(function (row, row_i) {
+
+                    var $row = jQuery('<tr/>');
+
+                    row.map(function (cell, cell_i) {
+
+                        var $cell = jQuery('<td/>');
+
+                        $cell.append('<input type="text" name="' + _this3.name + '[body][' + row_i + '][' + cell_i + ']" />');
+                        $cell.find('input[type="text"]').val(cell);
+
+                        $row.append($cell);
+                    });
+
+                    $row.append('<td class="fieldhelpers-field-table-delete-row">' + ('<button type="button" data-delete-row aria-label="' + _this3.l10n['delete_row'] + '">') + '<span class="dashicons dashicons-no" />' + '</button>' + '</td>');
+
+                    _this3.$ui.tbody.append($row);
+                });
+            }
+        }
+    }]);
+
+    return FieldTable;
+}(_field2.default);
+
+/**
+ * Finds and initializes all Table fields.
+ *
+ * @since 1.4.0
+ */
+
+
+var FieldTableInitialize = function () {
+
+    /**
+     * Class constructor.
+     *
+     * @since 1.4.0
+     *
+     * @param {jQuery} $root Root element to initialize fields inside.
+     */
+    function FieldTableInitialize($root) {
+        _classCallCheck(this, FieldTableInitialize);
+
+        var api = this;
+
+        this.fields = [];
+
+        var $fields = $root.find('[data-fieldhelpers-field-table]');
+
+        if ($fields.length) {
+
+            $fields.each(function () {
+
+                api.initializeField(jQuery(this));
+            });
+        }
+    }
+
+    /**
+     * Initializes the field.
+     *
+     * @since 1.4.0
+     *
+     * @param {jQuery} $field
+     */
+
+
+    _createClass(FieldTableInitialize, [{
+        key: 'initializeField',
+        value: function initializeField($field) {
+
+            this.fields.push({
+                $field: $field,
+                api: new FieldTable($field)
+            });
+        }
+    }]);
+
+    return FieldTableInitialize;
+}();
+
+exports.default = FieldTableInitialize;
+
+/***/ }),
+/* 10 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _field = __webpack_require__(0);
+
+var _field2 = _interopRequireDefault(_field);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+/**
+ * Media Field functionality.
+ *
+ * @since 1.4.0
+ */
+var FieldMedia = function (_Field) {
+    _inherits(FieldMedia, _Field);
+
+    /**
+     * Class constructor.
+     *
+     * @since 1.4.0
+     */
+    function FieldMedia($field) {
+        _classCallCheck(this, FieldMedia);
+
+        var _this = _possibleConstructorReturn(this, (FieldMedia.__proto__ || Object.getPrototypeOf(FieldMedia)).call(this, $field, 'media'));
+
+        _this.initField();
+        return _this;
+    }
+
+    /**
+     * Initializes the Media field.
+     *
+     * @since 1.4.0
+     */
+
+
+    _createClass(FieldMedia, [{
+        key: 'initField',
+        value: function initField() {
+
+            this.$ui = {
+                input: this.$field.find('[data-media-input]'),
+                addButton: this.$field.find('[data-add-media]'),
+                imagePreview: this.$field.find('[data-image-preview]'),
+                mediaPreview: this.$field.find('[data-media-preview]'),
+                removeButton: this.$field.find('[data-remove-media]')
+            };
+
+            this.mediaFrame = wp.media.frames.meta_image_frame = wp.media({
+                title: this.options.l10n['window_title']
+            });
+
+            this.placeholder = this.options.placeholder;
+            this.type = this.options.type;
+
+            this.imageProperties = {
+                previewSize: this.options.previewSize
+            };
+
+            this.setupHandlers();
+        }
+
+        /**
+         * Sets up the class handlers.
+         *
+         * @since 1.4.0
+         */
+
+    }, {
+        key: 'setupHandlers',
+        value: function setupHandlers() {
+            var _this2 = this;
+
+            this.$ui.addButton.click(function (e) {
+
+                e.preventDefault();
+                _this2.addMedia();
+            });
+
+            this.$ui.removeButton.click(function (e) {
+
+                e.preventDefault();
+                _this2.removeMedia();
+            });
+
+            this.mediaFrame.on('select', function (e) {
+
+                _this2.selectMedia();
+            });
+        }
+
+        /**
+         * Opens the media frame to add media.
+         *
+         * @since 1.4.0
+         */
+
+    }, {
+        key: 'addMedia',
+        value: function addMedia() {
+
+            this.mediaFrame.open();
+        }
+
+        /**
+         * Removes the currently selected media.
+         *
+         * @since 1.4.0
+         */
+
+    }, {
+        key: 'removeMedia',
+        value: function removeMedia() {
+
+            this.$ui.addButton.show();
+            this.$ui.removeButton.hide();
+            this.$ui.input.val('');
+
+            // Reset preview
+            switch (this.type) {
+
+                case 'image':
+
+                    this.$ui.imagePreview.attr('src', this.placeholder || '');
+
+                    break;
+
+                default:
+
+                    this.$ui.mediaPreview.html(this.placeholder || '&nbsp;');
+            }
+        }
+
+        /**
+         * Fires on selecting a piece of media.
+         *
+         * @since 1.4.0
+         */
+
+    }, {
+        key: 'selectMedia',
+        value: function selectMedia() {
+
+            var mediaAttachment = this.mediaFrame.state().get('selection').first().toJSON();
+
+            this.$ui.input.val(mediaAttachment.id);
+
+            this.$ui.addButton.hide();
+            this.$ui.removeButton.show();
+
+            // Preview
+            switch (this.type) {
+
+                case 'image':
+
+                    var previewUrl = mediaAttachment.url;
+
+                    if (mediaAttachment.sizes[this.imageProperties.previewSize]) {
+
+                        previewUrl = mediaAttachment.sizes[this.imageProperties.previewSize].url;
+                    }
+
+                    this.$ui.imagePreview.attr('src', previewUrl);
+                    break;
+
+                default:
+
+                    this.$ui.mediaPreview.html(mediaAttachment.url);
+            }
+        }
+    }]);
+
+    return FieldMedia;
+}(_field2.default);
+
+/**
+ * Finds and initializes all Media fields.
+ *
+ * @since 1.4.0
+ */
+
+
+var FieldMediaInitialize = function () {
+
+    /**
+     * Class constructor.
+     *
+     * @since 1.4.0
+     *
+     * @param {jQuery} $root Root element to initialize fields inside.
+     */
+    function FieldMediaInitialize($root) {
+        _classCallCheck(this, FieldMediaInitialize);
+
+        var api = this;
+
+        this.fields = [];
+
+        var $fields = $root.find('[data-fieldhelpers-field-media]');
+
+        if ($fields.length) {
+
+            if (!wp.media) {
+
+                console.error('Field Helpers Error: Trying to initialize Media field but media is not enqueued.');
+                return;
+            }
+
+            $fields.each(function () {
+
+                api.initializeField(jQuery(this));
+            });
+        }
+    }
+
+    /**
+     * Initializes the field.
+     *
+     * @since 1.4.0
+     *
+     * @param {jQuery} $field
+     */
+
+
+    _createClass(FieldMediaInitialize, [{
+        key: 'initializeField',
+        value: function initializeField($field) {
+
+            this.fields.push({
+                $field: $field,
+                api: new FieldMedia($field)
+            });
+        }
+    }]);
+
+    return FieldMediaInitialize;
+}();
+
+exports.default = FieldMediaInitialize;
+
+/***/ }),
+/* 11 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _field = __webpack_require__(0);
+
+var _field2 = _interopRequireDefault(_field);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+/**
+ * List Field functionality.
+ *
+ * @since 1.4.0
+ */
+var FieldList = function (_Field) {
+    _inherits(FieldList, _Field);
+
+    /**
+     * Class constructor.
+     *
+     * @since 1.4.0
+     */
+    function FieldList($field) {
+        _classCallCheck(this, FieldList);
+
+        var _this = _possibleConstructorReturn(this, (FieldList.__proto__ || Object.getPrototypeOf(FieldList)).call(this, $field, 'list'));
+
+        _this.initField();
+        return _this;
+    }
+
+    /**
+     * Initializes the list.
+     *
+     * @since 1.4.0
+     */
+
+
+    _createClass(FieldList, [{
+        key: 'initField',
+        value: function initField() {
+
+            this.$field.sortable(this.options);
+        }
+    }]);
+
+    return FieldList;
+}(_field2.default);
+
+/**
+ * Finds and initializes all List fields.
+ *
+ * @since 1.4.0
+ */
+
+
+var FieldListInitialize = function () {
+
+    /**
+     * Class constructor.
+     *
+     * @since 1.4.0
+     *
+     * @param {jQuery} $root Root element to initialize fields inside.
+     */
+    function FieldListInitialize($root) {
+        _classCallCheck(this, FieldListInitialize);
+
+        var api = this;
+
+        this.fields = [];
+
+        var $fields = $root.find('[data-fieldhelpers-field-list]');
+
+        if ($fields.length) {
+
+            if (!jQuery.isFunction(jQuery.fn.sortable)) {
+
+                console.error('Field Helpers Error: Trying to initialize List field but "jquery-ui-sortable" ' + 'is not enqueued.');
+                return;
+            }
+
+            $fields.each(function () {
+
+                api.initializeField(jQuery(this));
+            });
+        }
+    }
+
+    /**
+     * Initializes the field.
+     *
+     * @since 1.4.0
+     *
+     * @param {jQuery} $field
+     */
+
+
+    _createClass(FieldListInitialize, [{
+        key: 'initializeField',
+        value: function initializeField($field) {
+
+            this.fields.push({
+                $field: $field,
+                api: new FieldList($field)
+            });
+        }
+    }]);
+
+    return FieldListInitialize;
+}();
+
+exports.default = FieldListInitialize;
+
+/***/ }),
+/* 12 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _field = __webpack_require__(0);
+
+var _field2 = _interopRequireDefault(_field);
+
+var _fieldsInit = __webpack_require__(1);
+
+var _fieldsInit2 = _interopRequireDefault(_fieldsInit);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+/**
+ * Repeater Field functionality.
+ *
+ * @since 1.4.0
+ */
+var FieldRepeater = function (_Field) {
+    _inherits(FieldRepeater, _Field);
+
+    /**
+     * Class constructor.
+     *
+     * @since 1.4.0
+     */
+    function FieldRepeater($field) {
+        _classCallCheck(this, FieldRepeater);
+
+        var _this = _possibleConstructorReturn(this, (FieldRepeater.__proto__ || Object.getPrototypeOf(FieldRepeater)).call(this, $field, 'repeater'));
+
+        _this.initField();
+        return _this;
+    }
+
+    /**
+     * Initializes the Repeater.
+     *
+     * @since 1.4.0
+     */
+
+
+    _createClass(FieldRepeater, [{
+        key: 'initField',
+        value: function initField() {
+            var _this2 = this;
+
+            this.$repeaterList = this.$field.find('.fieldhelpers-field-repeater-list');
+
+            var api = this;
+
+            this.$field.repeater({
+                show: function show() {
+                    api.repeaterShow(jQuery(this));
+                },
+                hide: function hide(deleteItem) {
+                    api.repeaterHide(jQuery(this), deleteItem);
+                },
+                ready: function ready(setIndexes) {
+                    api.$repeaterList.on('sortupdate', setIndexes);
+                },
+                isFirstItemUndeletable: api.options.isFirstItemUndeletable
+            });
+
+            // Delete first item if allowed and empty
+            if (!this.options.isFirstItemUndeletable && this.options.empty) {
+
+                this.$repeaterList.find('.fieldhelpers-field-repeater-row').remove();
+            }
+
+            if (this.options.collapsable) {
+
+                this.initCollapsable();
+            }
+
+            if (this.options.sortable) {
+
+                if (!jQuery.isFunction(jQuery.fn.sortable)) {
+
+                    console.error('Field Helpers Error: Trying to initialize sortable Repeater field but "jquery-ui-sortable" ' + 'is not enqueued.');
+                    return;
+                } else {
+
+                    this.initSortable();
+                }
+            }
+
+            // Delay for other plugins
+            setTimeout(function () {
+                _this2.$field.trigger('repeater-init', [_this2.$field]);
+            }, 1);
+        }
+
+        /**
+         * Initializes the Collapsable feature, if enabled.
+         *
+         * @since 1.4.0
+         */
+
+    }, {
+        key: 'initCollapsable',
+        value: function initCollapsable() {
+
+            var api = this;
+
+            this.$field.on('click touchend', '[data-repeater-collapsable-handle]', function () {
+                console.log('click');
+                api.toggleCollapse(jQuery(this).closest('.fieldhelpers-field-repeater-row'));
+            });
+        }
+
+        /**
+         * Initializes the Sortable feature, if enabled.
+         *
+         * @since 1.4.0
+         */
+
+    }, {
+        key: 'initSortable',
+        value: function initSortable() {
+
+            var api = this;
+
+            this.$repeaterList.sortable({
+                axis: 'y',
+                handle: '.fieldhelpers-field-repeater-handle',
+                forcePlaceholderSize: true,
+                placeholder: 'fieldhelpers-sortable-placeholder',
+                stop: function stop(e, ui) {
+
+                    api.$repeaterList.trigger('list-update', [api.$repeaterList]);
+                }
+            });
+        }
+
+        /**
+         * Toggles a repeater item collapse.
+         *
+         * @since 1.4.0
+         *
+         * @param {jQuery} $item
+         */
+
+    }, {
+        key: 'toggleCollapse',
+        value: function toggleCollapse($item) {
+
+            var $content = $item.find('.fieldhelpers-field-repeater-content').first();
+            var status = $item.hasClass('opened') ? 'closing' : 'opening';
+
+            if (status === 'opening') {
+
+                $content.stop().slideDown();
+                $item.addClass('opened');
+                $item.removeClass('closed');
+            } else {
+
+                $content.stop().slideUp();
+                $item.addClass('closed');
+                $item.removeClass('opened');
+            }
+        }
+
+        /**
+         * Shows a new repeater item.
+         *
+         * @since 1.4.0
+         *
+         * @param {jQuery} $item Repeater item row.
+         */
+
+    }, {
+        key: 'repeaterShow',
+        value: function repeaterShow($item) {
+
+            this.$field.trigger('repeater-before-add-item', [$item]);
+
+            $item.slideDown();
+
+            if (this.$repeaterList.hasClass('collapsable')) {
+
+                $item.addClass('opened').removeClass('closed');
+
+                // Hide current title for new item and show default title
+                $item.find('.fieldhelpers-field-repeater-header span.collapsable-title').html($item.find('.fieldhelpers-field-repeater-header span.collapsable-title').data('collapsable-title-default'));
+
+                $item.find('.collapse-icon').css({ 'transform': 'rotate(-180deg)' });
+            }
+
+            // Re-initialize fields in new row
+            new _fieldsInit2.default($item);
+
+            this.$field.trigger('repeater-add-item', [$item]);
+        }
+
+        /**
+         * Removes a repeater item.
+         *
+         * @since 1.4.0
+         *
+         * @param {jQuery} $item Repeater item row.
+         * @param {function} deleteItem Callback for deleting the item.
+         */
+
+    }, {
+        key: 'repeaterHide',
+        value: function repeaterHide($item, deleteItem) {
+            var _this3 = this;
+
+            if (confirm(this.options.l10n['confirm_delete_text'])) {
+
+                this.$field.trigger('repeater-before-delete-item', [$item]);
+
+                $item.slideUp(400, function () {
+
+                    deleteItem();
+                    _this3.$field.trigger('repeater-delete-item', [$item]);
+                });
+            }
+        }
+    }]);
+
+    return FieldRepeater;
+}(_field2.default);
+
+/**
+ * Finds and initializes all Repeater fields.
+ *
+ * @since 1.4.0
+ */
+
+
+var FieldRepeaterInitialize = function () {
+
+    /**
+     * Class constructor.
+     *
+     * @since 1.4.0
+     *
+     * @param {jQuery} $root Root element to initialize fields inside.
+     */
+    function FieldRepeaterInitialize($root) {
+        _classCallCheck(this, FieldRepeaterInitialize);
+
+        var api = this;
+
+        this.fields = [];
+
+        var $fields = $root.find('[data-fieldhelpers-field-repeater]');
+
+        if ($fields.length) {
+
+            $fields.each(function () {
+
+                api.initializeField(jQuery(this));
+            });
+        }
+    }
+
+    /**
+     * Initializes the field.
+     *
+     * @since 1.4.0
+     *
+     * @param {jQuery} $field
+     */
+
+
+    _createClass(FieldRepeaterInitialize, [{
+        key: 'initializeField',
+        value: function initializeField($field) {
+
+            this.fields.push({
+                $field: $field,
+                api: new FieldRepeater($field)
+            });
+        }
+    }]);
+
+    return FieldRepeaterInitialize;
+}();
+
+exports.default = FieldRepeaterInitialize;
+
+/***/ }),
+/* 13 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _field = __webpack_require__(0);
+
+var _field2 = _interopRequireDefault(_field);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+/**
+ * Select Field functionality.
+ *
+ * @since 1.4.0
+ */
+var FieldSelect = function (_Field) {
+    _inherits(FieldSelect, _Field);
+
+    /**
+     * Class constructor.
+     *
+     * @since 1.4.0
+     */
+    function FieldSelect($field) {
+        _classCallCheck(this, FieldSelect);
+
+        var _this = _possibleConstructorReturn(this, (FieldSelect.__proto__ || Object.getPrototypeOf(FieldSelect)).call(this, $field, 'select'));
+
+        _this.initField();
+        return _this;
+    }
+
+    /**
+     * Initializes the select.
+     *
+     * @since 1.4.0
+     */
+
+
+    _createClass(FieldSelect, [{
+        key: 'initField',
+        value: function initField() {
+
+            if (!this.options.select2Disabled) {
+
+                if (!jQuery.isFunction(jQuery.fn.select2)) {
+
+                    console.error('Field Helpers Error: Trying to initialize Select field but "select2" ' + 'is not enqueued.');
+                    return;
+                }
+
+                this.setupSelect2Options();
+
+                this.$field.select2(this.options.select2Options);
+            }
+        }
+
+        /**
+         * Sets up languages.
+         *
+         * @since 1.4.0
+         */
+
+    }, {
+        key: 'setupL10n',
+        value: function setupL10n() {
+            var _this2 = this;
+
+            if (Object.keys(this.options.select2Options.language).length > 0) {
+
+                Object.keys(this.options.select2Options.language).map(function (id) {
+
+                    var text = _this2.options.select2Options.language[id];
+
+                    // All languages must be functions. Turn all into functions.
+                    _this2.options.select2Options.language[id] = function (args) {
+                        return text;
+                    };
+                });
+            }
+        }
+
+        /**
+         * Sets up Select2 arguments, allowing for callback arguments.
+         *
+         * @since 1.4.2
+         */
+
+    }, {
+        key: 'setupSelect2Options',
+        value: function setupSelect2Options() {
+            var _this3 = this;
+
+            this.setupL10n();
+
+            // List of available Select2 options that are callbacks
+            var callbackOptions = ['escapeMarkup', 'initSelection', 'matcher', 'query', 'sorter', 'templateResult', 'templateSelection', 'tokenizer'];
+
+            Object.keys(this.options.select2Options).map(function (name) {
+
+                if (callbackOptions.indexOf(name) !== -1) {
+
+                    var callbackName = _this3.options.select2Options[name];
+
+                    if (typeof window[callbackName] === 'function') {
+
+                        _this3.options.select2Options[name] = window[callbackName];
+                    }
+                }
+            });
+
+            // Automatically prefix selected items with optgroup label, if using optgroups
+            if (this.options.optGroups && this.options.optGroupSelectionPrefix && typeof this.options.select2Options.templateSelection === 'undefined') {
+
+                this.options.select2Options.templateSelection = function (item) {
+
+                    var optGroup = jQuery(item.element).closest('optgroup').attr('label').trim();
+
+                    return optGroup + ': ' + item.text;
+                };
+            }
+        }
+
+        /**
+         * Resets the field.
+         *
+         * @since 1.4.0
+         */
+
+    }, {
+        key: 'fieldCleanup',
+        value: function fieldCleanup() {
+
+            if (this.options.select2Disabled) {
+
+                return;
+            }
+
+            var $oldSelect = this.$field.next('.select2');
+
+            if ($oldSelect.length) {
+
+                $oldSelect.remove();
+            }
+
+            this.$field.removeClass('select2-hidden-accessible').removeAttr('tablindex aria-hidden');
+        }
+
+        /**
+         * Sets the field to default. Override in child class if need different method.
+         *
+         * @since 1.4.0
+         */
+
+    }, {
+        key: 'setDefault',
+        value: function setDefault() {
+
+            this.$field.find('option:selected').prop('selected', false);
+            this.$field.trigger('change');
+        }
+    }]);
+
+    return FieldSelect;
+}(_field2.default);
+
+/**
+ * Finds and initializes all Select fields.
+ *
+ * @since 1.4.0
+ */
+
+
+var FieldSelectInitialize = function () {
+
+    /**
+     * Class constructor.
+     *
+     * @since 1.4.0
+     *
+     * @param {jQuery} $root Root element to initialize fields inside.
+     */
+    function FieldSelectInitialize($root) {
+        _classCallCheck(this, FieldSelectInitialize);
+
+        var api = this;
+
+        this.fields = [];
+
+        var $fields = $root.find('[data-fieldhelpers-field-select]');
+
+        if ($fields.length) {
+
+            $fields.each(function () {
+
+                api.initializeField(jQuery(this));
+            });
+        }
+    }
+
+    /**
+     * Initializes the field.
+     *
+     * @since 1.4.0
+     *
+     * @param {jQuery} $field
+     */
+
+
+    _createClass(FieldSelectInitialize, [{
+        key: 'initializeField',
+        value: function initializeField($field) {
+
+            this.fields.push({
+                $field: $field,
+                api: new FieldSelect($field)
+            });
+        }
+    }]);
+
+    return FieldSelectInitialize;
+}();
+
+exports.default = FieldSelectInitialize;
+
+/***/ }),
+/* 14 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _field = __webpack_require__(0);
+
+var _field2 = _interopRequireDefault(_field);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+/**
+ * TextArea Field functionality.
+ *
+ * @since 1.4.0
+ */
+var FieldTextArea = function (_Field) {
+    _inherits(FieldTextArea, _Field);
+
+    /**
+     * Class constructor.
+     *
+     * @since 1.4.0
+     */
+    function FieldTextArea($field) {
+        _classCallCheck(this, FieldTextArea);
+
+        var _this = _possibleConstructorReturn(this, (FieldTextArea.__proto__ || Object.getPrototypeOf(FieldTextArea)).call(this, $field, 'textarea'));
+
+        _this.initField();
+        return _this;
+    }
+
+    /**
+     * Initializes the WYSIWYG.
+     *
+     * @since 1.4.0
+     */
+
+
+    _createClass(FieldTextArea, [{
+        key: 'initField',
+        value: function initField() {
+
+            if (this.options.wysiwyg) {
+
+                if (!wp.editor) {
+
+                    console.error('Field Helpers Error: Trying to initialize a WYSIWYG Text Area field but "wp_editor" ' + 'is not enqueued.');
+                    return;
+                }
+
+                var settings = jQuery.extend(this.getDefaultEditorSettings(), this.options.wysiwygOptions);
+
+                console.log(settings);
+                wp.editor.initialize(this.$field.attr('id'), settings);
+            }
+        }
+
+        /**
+         * Resets the field.
+         *
+         * @since 1.4.0
+         */
+
+    }, {
+        key: 'fieldCleanup',
+        value: function fieldCleanup() {
+
+            if (this.options.wysiwyg) {
+
+                var id = this.$field.attr('id');
+
+                if (window.tinymce.get(id)) {
+
+                    wp.editor.remove(id);
+                } else {
+
+                    this.$field.appendTo(this.$wrapper.find('.fieldhelpers-field-content'));
+                    this.$wrapper.find('.wp-editor-wrap').remove();
+                }
+            }
+        }
+
+        /**
+         * Fires before deleting the item from a repeater.
+         *
+         * Removes from wp.editor.
+         *
+         * @since 1.4.0
+         */
+
+    }, {
+        key: 'repeaterBeforeDeleteSelf',
+        value: function repeaterBeforeDeleteSelf() {
+
+            this.fieldCleanup();
+        }
+
+        /**
+         * Fires on Repeat delete item.
+         *
+         * Adds slight delay to field re-initialization.
+         *
+         * @since 1.4.0
+         */
+
+    }, {
+        key: 'repeaterOnDeleteItem',
+        value: function repeaterOnDeleteItem() {
+            var _this2 = this;
+
+            this.fieldCleanup();
+            this.repeaterSetID();
+
+            // Add slight delay because all repeater item WYSIWYG's must be unitialized before re-initializing to prevent
+            // ID overlap.
+            setTimeout(function () {
+                _this2.initField();
+            }, 1);
+        }
+
+        /**
+         * Fires on Repeat sort item.
+         *
+         * Adds slight delay to field re-initialization.
+         *
+         * @since 1.4.0
+         */
+
+    }, {
+        key: 'repeaterOnSort',
+        value: function repeaterOnSort() {
+            var _this3 = this;
+
+            this.fieldCleanup();
+            this.repeaterSetID();
+
+            // Add slight delay because all repeater item WYSIWYG's must be unitialized before re-initializing to prevent
+            // ID overlap.
+            setTimeout(function () {
+                _this3.initField();
+            }, 1);
+        }
+
+        /**
+         * Tries to get default editor settings.
+         *
+         * @since 1.4.0
+         *
+         * @return {{}}
+         */
+
+    }, {
+        key: 'getDefaultEditorSettings',
+        value: function getDefaultEditorSettings() {
+
+            if (!jQuery.isFunction(wp.editor.getDefaultSettings)) {
+
+                return {};
+            } else {
+
+                return wp.editor.getDefaultSettings();
+            }
+        }
+    }]);
+
+    return FieldTextArea;
+}(_field2.default);
+
+/**
+ * Finds and initializes all TextArea fields.
+ *
+ * @since 1.4.0
+ */
+
+
+var FieldTextAreaInitialize = function () {
+
+    /**
+     * Class constructor.
+     *
+     * @since 1.4.0
+     *
+     * @param {jQuery} $root Root element to initialize fields inside.
+     */
+    function FieldTextAreaInitialize($root) {
+        _classCallCheck(this, FieldTextAreaInitialize);
+
+        var api = this;
+
+        this.fields = [];
+
+        var $fields = $root.find('[data-fieldhelpers-field-textarea]');
+
+        if ($fields.length) {
+
+            $fields.each(function () {
+
+                api.initializeField(jQuery(this));
+            });
+        }
+    }
+
+    /**
+     * Initializes the field.
+     *
+     * @since 1.4.0
+     *
+     * @param {jQuery} $field
+     */
+
+
+    _createClass(FieldTextAreaInitialize, [{
+        key: 'initializeField',
+        value: function initializeField($field) {
+
+            this.fields.push({
+                $field: $field,
+                api: new FieldTextArea($field)
+            });
+        }
+    }]);
+
+    return FieldTextAreaInitialize;
+}();
+
+exports.default = FieldTextAreaInitialize;
+
+/***/ }),
+/* 15 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _field = __webpack_require__(0);
+
+var _field2 = _interopRequireDefault(_field);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+/**
+ * Checkbox Field functionality.
+ *
+ * @since 1.4.0
+ */
+var FieldCheckbox = function (_Field) {
+    _inherits(FieldCheckbox, _Field);
+
+    /**
+     * Class constructor.
+     *
+     * @since 1.4.0
+     */
+    function FieldCheckbox($field) {
+        _classCallCheck(this, FieldCheckbox);
+
+        var _this = _possibleConstructorReturn(this, (FieldCheckbox.__proto__ || Object.getPrototypeOf(FieldCheckbox)).call(this, $field, 'checkbox'));
+
+        _this.initField();
+        return _this;
+    }
+
+    /**
+     * Initializes the select.
+     *
+     * @since 1.4.0
+     */
+
+
+    _createClass(FieldCheckbox, [{
+        key: 'initField',
+        value: function initField() {
+
+            this.$ui = {
+                checkboxes: this.$field.find('input[type="checkbox"]')
+            };
+
+            this.setupHandlers();
+
+            this.$field.find('input:checked').change();
+        }
+
+        /**
+         * Sets up class handlers.
+         *
+         * @since 1.4.0
+         */
+
+    }, {
+        key: 'setupHandlers',
+        value: function setupHandlers() {
+
+            var api = this;
+
+            this.$ui.checkboxes.change(function () {
+                api.handleChange(jQuery(this));
+            });
+        }
+
+        /**
+         * Fires on checkbox change.
+         *
+         * @since 1.4.0
+         *
+         * @param {jQuery} $input Checkbox input.
+         */
+
+    }, {
+        key: 'handleChange',
+        value: function handleChange($input) {
+
+            if ($input.prop('checked')) {
+
+                this.setActive($input.closest('.fieldhelpers-field-checkbox-row'));
+            } else {
+
+                this.setInactive($input.closest('.fieldhelpers-field-checkbox-row'));
+            }
+        }
+
+        /**
+         * Sets the checkbox row as active.
+         *
+         * @since 1.4.0
+         *
+         * @param {jQuery} $row
+         */
+
+    }, {
+        key: 'setActive',
+        value: function setActive($row) {
+
+            $row.addClass('fieldhelpers-field-checkbox-row-active');
+        }
+
+        /**
+         * Sets the checkbox row as inactive.
+         *
+         * @since 1.4.0
+         *
+         * @param {jQuery} $row
+         */
+
+    }, {
+        key: 'setInactive',
+        value: function setInactive($row) {
+
+            $row.removeClass('fieldhelpers-field-checkbox-row-active');
+        }
+
+        /**
+         * Sets the ID to be unique, based off the repeater item index.
+         *
+         * For checkboxes, there will be multiple IDs in each, and need to be set accordingly.
+         *
+         * @since 1.4.0
+         */
+
+    }, {
+        key: 'repeaterSetID',
+        value: function repeaterSetID() {
+
+            var ID = this.options.id;
+            var $rows = this.$field.find('.fieldhelpers-field-checkbox-row');
+            var index = this.$field.closest('[data-repeater-item]').index();
+
+            $rows.each(function () {
+
+                var $field = jQuery(this).find('input[type="checkbox"]');
+                var $label = $field.next('label');
+                var fieldIndex = jQuery(this).index();
+                var newID = ID + '_' + index + '_' + fieldIndex;
+
+                $field.attr('id', newID);
+                $label.attr('for', newID);
+            });
+        }
+
+        /**
+         * Sets the field to default.
+         *
+         * @since 1.4.0
+         */
+
+    }, {
+        key: 'setDefault',
+        value: function setDefault() {
+
+            if (this.options.default) {
+
+                this.$field.find('[value="' + this.options.default + '"]').prop('checked', true).change();
+            }
+        }
+    }]);
+
+    return FieldCheckbox;
+}(_field2.default);
+
+/**
+ * Finds and initializes all Checkbox fields.
+ *
+ * @since 1.4.0
+ */
+
+
+var FieldCheckboxInitialize = function () {
+
+    /**
+     * Class constructor.
+     *
+     * @since 1.4.0
+     *
+     * @param {jQuery} $root Root element to initialize fields inside.
+     */
+    function FieldCheckboxInitialize($root) {
+        _classCallCheck(this, FieldCheckboxInitialize);
+
+        var api = this;
+
+        this.fields = [];
+
+        var $fields = $root.find('[data-fieldhelpers-field-checkbox]');
+
+        if ($fields.length) {
+
+            $fields.each(function () {
+
+                api.initializeField(jQuery(this));
+            });
+        }
+    }
+
+    /**
+     * Initializes the field.
+     *
+     * @since 1.4.0
+     *
+     * @param {jQuery} $field
+     */
+
+
+    _createClass(FieldCheckboxInitialize, [{
+        key: 'initializeField',
+        value: function initializeField($field) {
+
+            this.fields.push({
+                $field: $field,
+                api: new FieldCheckbox($field)
+            });
+        }
+    }]);
+
+    return FieldCheckboxInitialize;
+}();
+
+exports.default = FieldCheckboxInitialize;
+
+/***/ }),
+/* 16 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _field = __webpack_require__(0);
+
+var _field2 = _interopRequireDefault(_field);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+/**
+ * Radio Field functionality.
+ *
+ * @since 1.4.0
+ */
+var FieldRadio = function (_Field) {
+    _inherits(FieldRadio, _Field);
+
+    /**
+     * Class constructor.
+     *
+     * @since 1.4.0
+     */
+    function FieldRadio($field) {
+        _classCallCheck(this, FieldRadio);
+
+        var _this = _possibleConstructorReturn(this, (FieldRadio.__proto__ || Object.getPrototypeOf(FieldRadio)).call(this, $field, 'radio'));
+
+        _this.initField();
+        return _this;
+    }
+
+    /**
+     * Initializes the select.
+     *
+     * @since 1.4.0
+     */
+
+
+    _createClass(FieldRadio, [{
+        key: 'initField',
+        value: function initField() {
+
+            this.$ui = {
+                radios: this.$field.find('input[type="radio"]')
+            };
+
+            this.setupHandlers();
+
+            this.$field.find('input:checked').change();
+        }
+
+        /**
+         * Sets up class handlers.
+         *
+         * @since 1.4.0
+         */
+
+    }, {
+        key: 'setupHandlers',
+        value: function setupHandlers() {
+
+            var api = this;
+
+            this.$ui.radios.change(function () {
+                api.handleChange(jQuery(this));
+            });
+        }
+
+        /**
+         * Fires on radio change.
+         *
+         * @since 1.4.0
+         *
+         * @param {jQuery} $input Checkbox input.
+         */
+
+    }, {
+        key: 'handleChange',
+        value: function handleChange($input) {
+
+            this.setInactive(this.$ui.radios.closest('.fieldhelpers-field-radio-row'));
+            this.setActive($input.closest('.fieldhelpers-field-radio-row'));
+        }
+
+        /**
+         * Sets the radio row as active.
+         *
+         * @since 1.4.0
+         *
+         * @param {jQuery} $row
+         */
+
+    }, {
+        key: 'setActive',
+        value: function setActive($row) {
+
+            $row.addClass('fieldhelpers-field-radio-row-active');
+        }
+
+        /**
+         * Sets the radio row as inactive.
+         *
+         * @since 1.4.0
+         *
+         * @param {jQuery} $row
+         */
+
+    }, {
+        key: 'setInactive',
+        value: function setInactive($row) {
+
+            $row.removeClass('fieldhelpers-field-radio-row-active');
+        }
+
+        /**
+         * Sets the ID to be unique, based off the repeater item index.
+         *
+         * For radios, there will be multiple IDs in each, and need to be set accordingly.
+         *
+         * @since 1.4.0
+         */
+
+    }, {
+        key: 'repeaterSetID',
+        value: function repeaterSetID() {
+
+            var ID = this.options.id;
+            var $rows = this.$field.find('.fieldhelpers-field-radio-row');
+            var index = this.$field.closest('[data-repeater-item]').index();
+
+            $rows.each(function () {
+
+                var $field = jQuery(this).find('input[type="radio"]');
+                var $label = $field.next('label');
+                var fieldIndex = jQuery(this).index();
+                var newID = ID + '_' + index + '_' + fieldIndex;
+
+                $field.attr('id', newID);
+                $label.attr('for', newID);
+            });
+        }
+
+        /**
+         * Sets the field to default.
+         *
+         * @since 1.4.0
+         */
+
+    }, {
+        key: 'setDefault',
+        value: function setDefault() {
+
+            if (this.options.default) {
+
+                this.$field.find('[value="' + this.options.default + '"]').prop('checked', true).change();
+            }
+        }
+    }]);
+
+    return FieldRadio;
+}(_field2.default);
+
+/**
+ * Finds and initializes all Radio fields.
+ *
+ * @since 1.4.0
+ */
+
+
+var FieldRadioInitialize = function () {
+
+    /**
+     * Class constructor.
+     *
+     * @since 1.4.0
+     *
+     * @param {jQuery} $root Root element to initialize fields inside.
+     */
+    function FieldRadioInitialize($root) {
+        _classCallCheck(this, FieldRadioInitialize);
+
+        var api = this;
+
+        this.fields = [];
+
+        var $fields = $root.find('[data-fieldhelpers-field-radio]');
+
+        if ($fields.length) {
+
+            $fields.each(function () {
+
+                api.initializeField(jQuery(this));
+            });
+        }
+    }
+
+    /**
+     * Initializes the field.
+     *
+     * @since 1.4.0
+     *
+     * @param {jQuery} $field
+     */
+
+
+    _createClass(FieldRadioInitialize, [{
+        key: 'initializeField',
+        value: function initializeField($field) {
+
+            this.fields.push({
+                $field: $field,
+                api: new FieldRadio($field)
+            });
+        }
+    }]);
+
+    return FieldRadioInitialize;
+}();
+
+exports.default = FieldRadioInitialize;
+
+/***/ }),
+/* 17 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _field = __webpack_require__(0);
+
+var _field2 = _interopRequireDefault(_field);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+/**
+ * Toggle Field functionality.
+ *
+ * @since 1.4.0
+ */
+var FieldToggle = function (_Field) {
+    _inherits(FieldToggle, _Field);
+
+    /**
+     * Class constructor.
+     *
+     * @since 1.4.0
+     */
+    function FieldToggle($field) {
+        _classCallCheck(this, FieldToggle);
+
+        var _this = _possibleConstructorReturn(this, (FieldToggle.__proto__ || Object.getPrototypeOf(FieldToggle)).call(this, $field, 'toggle'));
+
+        _this.initField();
+        return _this;
+    }
+
+    /**
+     * Initializes the select.
+     *
+     * @since 1.4.0
+     */
+
+
+    _createClass(FieldToggle, [{
+        key: 'initField',
+        value: function initField() {
+            var _this2 = this;
+
+            this.getUI();
+
+            // Initial change trigger to help other plugins
+            setTimeout(function () {
+                _this2.$field.trigger('change', [_this2.$ui.input.val()]);
+            }, 1);
+
+            this.setupHandlers();
+        }
+
+        /**
+         * Retrieves the UI.
+         *
+         * @since 1.4.0
+         */
+
+    }, {
+        key: 'getUI',
+        value: function getUI() {
+
+            this.$ui = {
+                slider: this.$field.find('.fieldhelpers-field-toggle-slider'),
+                input: this.$field.find('input[type="hidden"]')
+            };
+        }
+
+        /**
+         * Sets up class handlers.
+         *
+         * @since 1.4.0
+         */
+
+    }, {
+        key: 'setupHandlers',
+        value: function setupHandlers() {
+
+            var api = this;
+
+            this.$ui.slider.click(function () {
+                api.handleClick();
+            });
+        }
+
+        /**
+         * Return if field is checked or not.
+         *
+         * @since 1.4.0
+         *
+         * @returns {*}
+         */
+
+    }, {
+        key: 'isChecked',
+        value: function isChecked() {
+
+            return this.$field.hasClass('checked');
+        }
+
+        /**
+         * Fires on toggle change.
+         *
+         * @since 1.4.0
+         */
+
+    }, {
+        key: 'handleClick',
+        value: function handleClick() {
+
+            if (this.isChecked()) {
+
+                this.$ui.input.val(this.options.uncheckedValue);
+                this.$field.removeClass('checked');
+            } else {
+
+                this.$ui.input.val(this.options.checkedValue);
+                this.$field.addClass('checked');
+            }
+
+            this.$field.trigger('change', [this.$ui.input.val()]);
+        }
+    }]);
+
+    return FieldToggle;
+}(_field2.default);
+
+/**
+ * Finds and initializes all Toggle fields.
+ *
+ * @since 1.4.0
+ */
+
+
+var FieldToggleInitialize = function () {
+
+    /**
+     * Class constructor.
+     *
+     * @since 1.4.0
+     *
+     * @param {jQuery} $root Root element to initialize fields inside.
+     */
+    function FieldToggleInitialize($root) {
+        _classCallCheck(this, FieldToggleInitialize);
+
+        var api = this;
+
+        this.fields = [];
+
+        var $fields = $root.find('[data-fieldhelpers-field-toggle]');
+
+        if ($fields.length) {
+
+            $fields.each(function () {
+
+                api.initializeField(jQuery(this));
+            });
+        }
+    }
+
+    /**
+     * Initializes the field.
+     *
+     * @since 1.4.0
+     *
+     * @param {jQuery} $field
+     */
+
+
+    _createClass(FieldToggleInitialize, [{
+        key: 'initializeField',
+        value: function initializeField($field) {
+
+            this.fields.push({
+                $field: $field,
+                api: new FieldToggle($field)
+            });
+        }
+    }]);
+
+    return FieldToggleInitialize;
+}();
+
+exports.default = FieldToggleInitialize;
+
+/***/ })
+/******/ ]);

--- a/assets/src/js/admin/fields/field-datetimepicker.js
+++ b/assets/src/js/admin/fields/field-datetimepicker.js
@@ -45,7 +45,7 @@ class FieldDateTimePicker extends Field {
 
         this.options.datetimepickerOptions.altField = this.$hiddenField;
 
-        this.$field.datetimepicker(this.options);
+        this.$field.datetimepicker(this.options.datetimepickerOptions);
     }
 
     /**

--- a/assets/src/scss/admin/app.scss
+++ b/assets/src/scss/admin/app.scss
@@ -8,6 +8,7 @@
 @import "fields/field-checkbox";
 @import "fields/field-colorpicker";
 @import "fields/field-datepicker";
+@import "fields/field-datetimepicker";
 @import "fields/field-hidden";
 @import "fields/field-list";
 @import "fields/field-media";

--- a/assets/src/scss/admin/fields/_field-datetimepicker.scss
+++ b/assets/src/scss/admin/fields/_field-datetimepicker.scss
@@ -1,0 +1,35 @@
+.ui-datepicker-buttonpane {
+	
+	padding: 6px;
+
+	.ui-datepicker-current, .ui-datepicker-close {
+
+		// Copied from .wp-core-ui .button
+		// jQuery UI is supposed to provide a `classes` option to add Class Names to elements, but it doesn't appear to work with Datepicker or Datetimepicker or Timepicker
+		// Documentation referencing it: http://api.jqueryui.com/datepicker/#theming
+		color: #555;
+		border-color: #cccccc;
+		background: #f7f7f7;
+		box-shadow: 0 1px 0 #cccccc;
+		vertical-align: top;
+		display: inline-block;
+		text-decoration: none;
+		font-size: 13px;
+		line-height: 26px;
+		height: 28px;
+		margin: 0;
+		padding: 0 10px 1px;
+		cursor: pointer;
+		border-width: 1px;
+		border-style: solid;
+		-webkit-appearance: none;
+		border-radius: 3px;
+		white-space: nowrap;
+		box-sizing: border-box;
+		
+		// Additional
+		margin-right: 6px;
+
+	}
+
+}

--- a/core/fields/class-rbm-fh-field-datepicker.php
+++ b/core/fields/class-rbm-fh-field-datepicker.php
@@ -44,8 +44,14 @@ class RBM_FH_Field_DatePicker extends RBM_FH_Field {
 
 		// Cannot use function in property declaration
 		$this->defaults['format'] = get_option( 'date_format', 'F j, Y' );
+		
+		$this->defaults['datepicker_args']['dateFormat'] = RBM_FH_Field_DateTimePicker::php_date_to_jquery_ui( $this->defaults['format'] );
 
 		$args['default'] = current_time( $this->defaults['format'] );
+		
+		if ( ! isset( $args['datepicker_args'] ) ) {
+			$args['datepicker_args'] = array();
+		}
 
 		// Default options
 		$args['datepicker_args'] = wp_parse_args( $args['datepicker_args'], $this->defaults['datepicker_args'] );

--- a/core/fields/class-rbm-fh-field-datetimepicker.php
+++ b/core/fields/class-rbm-fh-field-datetimepicker.php
@@ -30,7 +30,8 @@ class RBM_FH_Field_DateTimePicker extends RBM_FH_Field {
 			'altFormat'        => 'yymmdd',
 			'altTimeFormat'    => 'HH:mm',
 			'altFieldTimeOnly' => false,
-			'timeFormat'       => 'hh:mm tt',
+			'dateFormat'       => 'MM d, yy',
+			'timeFormat'       => 'h:mm tt',
 			'controlType'      => 'select',
 		),
 	);
@@ -45,11 +46,22 @@ class RBM_FH_Field_DateTimePicker extends RBM_FH_Field {
 	 * @var mixed $value
 	 */
 	function __construct( $name, $args = array() ) {
+		
+		$date_format_php = get_option( 'date_format', 'F j, Y' );
+		$time_format_php = get_option( 'time_format', 'g:i a' );
 
 		// Cannot use function in property declaration
-		$this->defaults['format'] = get_option( 'date_format', 'F j, Y' ) . ' ' . get_option( 'time_format', 'g:i a' );
+		$this->defaults['format'] = $date_format_php . ' ' . $time_format_php;
+		
+		// Ensure the Date/Time Format matches the stored format in WordPress
+		$this->defaults['datetimepicker_args']['dateFormat'] = RBM_FH_Field_DateTimePicker::php_date_to_jquery_ui( $date_format_php );
+		$this->defaults['datetimepicker_args']['timeFormat'] = RBM_FH_Field_DateTimePicker::php_date_to_jquery_ui( $time_format_php );
 
 		$args['default'] = current_time( $this->defaults['format'] );
+		
+		if ( ! isset( $args['datetimepicker_args'] ) ) {
+			$args['datetimepicker_args'] = array();
+		}
 
 		// Default options
 		$args['datetimepicker_args'] = wp_parse_args( $args['datetimepicker_args'], $this->defaults['datetimepicker_args'] );
@@ -84,4 +96,103 @@ class RBM_FH_Field_DateTimePicker extends RBM_FH_Field {
 
 		do_action( "{$args['prefix']}_fieldhelpers_do_field", 'datetimepicker', $args, $name, $value );
 	}
+	
+	/**
+	 * Converts a PHP Date/Time Format to jQuery UI Date/Time
+	 * Cleaned up variant of http://stackoverflow.com/a/16725290
+	 * 
+	 * @since {{VERSION}}
+	 * 
+	 * @param string $php_format PHP Date Format
+	 * @return string jQuery UI Date Format
+	 */
+	public static function php_date_to_jquery_ui( $php_format ) {
+		
+		$format_map = array(
+			// Day
+			'd' => 'dd',
+			'D' => 'D',
+			'j' => 'd',
+			'l' => 'DD',
+			'N' => '',
+			'S' => '',
+			'w' => '',
+			'z' => 'o',
+			// Week
+			'W' => '',
+			// Month
+			'F' => 'MM',
+			'm' => 'mm',
+			'M' => 'M',
+			'n' => 'm',
+			't' => '',
+			// Year
+			'L' => '',
+			'o' => '',
+			'Y' => 'yy',
+			'y' => 'y',
+			// Time
+			'a' => 'tt',
+			'A' => 'TT',
+			'B' => '',
+			'g' => 'h',
+			'G' => 'H',
+			'h' => 'hh',
+			'H' => 'HH',
+			'i' => 'mm',
+			's' => 'ss',
+			'u' => 'c'
+		);
+
+		$jqueryui_format = '';
+		$escaped = false;
+
+		for ( $index = 0; $index < strlen( $php_format ); $index++ ) {
+
+			$char = $php_format[$index];
+
+			if ( $char === '\\' ) { // If Character is an Escaping Slash
+
+				$index++;
+
+				// If we haven't already escaped a character, output it alongside the next character
+				if ( ! $escaped ) {
+
+					$jqueryui_format .= '\'' . $php_format[ $index ];
+					$escaped = true;
+
+				}
+				else  {
+
+					// Ignore, we've already escaped it
+					$jqueryui_format .= $php_format[ $index ];
+
+				}
+
+			}
+			else {
+
+				// Reset Escaped Status for next loop
+				if ( $escaped ) {
+
+					$jqueryui_format .= "'";
+					$escaped = false;
+
+				}
+
+				// Make necessary replacements via our PHP->jQuery UI Format Map
+				if ( isset( $format_map[ $char ] ) ) {
+					$jqueryui_format .= $format_map[ $char ];
+				}
+				else {
+					$jqueryui_format .= $char;
+				}
+
+			}
+
+		}
+
+		return $jqueryui_format;	
+	}
+	
 }

--- a/core/fields/class-rbm-fh-field-timepicker.php
+++ b/core/fields/class-rbm-fh-field-timepicker.php
@@ -47,8 +47,14 @@ class RBM_FH_Field_TimePicker extends RBM_FH_Field {
 
 		// Cannot use function in property declaration
 		$this->defaults['format'] = get_option( 'time_format', 'g:i a' );
+		
+		$this->defaults['timepicker_args']['timeFormat'] = RBM_FH_Field_DateTimePicker::php_date_to_jquery_ui( $this->defaults['format'] );
 
 		$args['default'] = current_time( $this->defaults['format'] );
+		
+		if ( ! isset( $args['timepicker_args'] ) ) {
+			$args['timepicker_args'] = array();
+		}
 
 		// Default options
 		$args['timepicker_args'] = wp_parse_args( $args['timepicker_args'], $this->defaults['timepicker_args'] );


### PR DESCRIPTION
This also cleans up PHP Errors that existed among all three Datepicker, Datetimepicker, and Timepicker if no Args were set for them.

The reason for the bug were two-fold:

1. The Datetimepicker Options were not being passed to the Datetimepicker itself
2. The `dateFormat` and `timeFormat` options need to match the Preview field. To ensure this is correct, a PHP Date Format->jQuery UI Date Format method had to be added to convert the format default argument (which is grabbed from the WordPress settings, which is stored as a PHP Date Format) to ones compatible with jQuery UI.

## Important

The downside to this (but kind of unavoidable for the Datetimepicker Field at least) is that this means that if a User were to define their own `format` argument, they would also need to define their own `dateFormat` and/or `timeFormat` argument to match. For Datepicker and Timepicker we could arguably generate these for them in the Constructor if a custom `format` is defined, but for Datetimepicker, it is much harder for us to separate what is the Date Format and what is the Time Format that was provided for us to convert.

Perhaps some clever Regex could handle it, but that could lead to problems of its own. A solution like that would need to be thought out very thoroughly. 

Since the _default_ `format` option pulls from the WP Settings for each of the three \*picker fields, I think it is alright though.